### PR TITLE
ci: Bump actions/checkout from 4 to 6

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,7 +14,7 @@ jobs:
     name: markdown-lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
           node-version: "20"
@@ -25,7 +25,7 @@ jobs:
     name: dead-links
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Run lychee
         uses: lycheeverse/lychee-action@v2
         with:
@@ -36,7 +36,7 @@ jobs:
     name: consistency-and-versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -49,7 +49,7 @@ jobs:
     name: plugin-structure
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -62,7 +62,7 @@ jobs:
     name: plugin-generator-drift
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
@@ -79,7 +79,7 @@ jobs:
     name: html-artifacts
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"


### PR DESCRIPTION
Replaces Dependabot PR #3, which developed a merge conflict after the setup-node and setup-python bumps landed on main.

Same upgrade: `actions/checkout@v4` → `@v6` across all six jobs in `.github/workflows/validate.yml`.

Closes #3.