### PR TITLE
docs: strengthen collaboration-safe output contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 - **Setup questionnaire explanations**: each of the 13 interview questions now includes a brief `→` note explaining how the answer affects the resulting setup.
 - **`docs/collaboration.md`**: added a dedicated human collaboration guide for shared KB workspaces, including layer responsibilities, review points, action-mode clarity, and failure recovery norms.
 - **`docs/first-run-acceptance.md`**: added a deterministic onboarding acceptance path with explicit install-vs-init boundaries, expected first outputs, scaffold checks, and a team-lead rollout checklist.
+- **Collaboration-safe output contract**: added `plugins/kb/skills/kb-management/references/output-contract.md`, tightened output semantics in `kb-management`, and updated examples so read-only, proposed, and applied actions are auditable for humans.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -180,8 +180,9 @@ agentic-kb/
 2. [`docs/REFERENCE.md`](docs/REFERENCE.md) — architecture, layout, formats, and contracts.
 3. [`docs/first-run-acceptance.md`](docs/first-run-acceptance.md) — the deterministic first-run acceptance path for onboarding and rollout checks.
 4. [`docs/collaboration.md`](docs/collaboration.md) — the human collaboration contract for shared KB workspaces.
-5. [`docs/examples/day-in-the-life.md`](docs/examples/day-in-the-life.md) — what it feels like in practice.
-6. [`plugins/kb/skills/kb-management/SKILL.md`](plugins/kb/skills/kb-management/SKILL.md) — the full behavioral spec (this IS the spec).
+5. [`plugins/kb/skills/kb-management/references/output-contract.md`](plugins/kb/skills/kb-management/references/output-contract.md) — the collaboration-safe response contract for auditability and handoffs.
+6. [`docs/examples/day-in-the-life.md`](docs/examples/day-in-the-life.md) — what it feels like in practice.
+7. [`plugins/kb/skills/kb-management/SKILL.md`](plugins/kb/skills/kb-management/SKILL.md) — the full behavioral spec (this IS the spec).
 
 ## Status
 

--- a/docs/examples/day-in-the-life.md
+++ b/docs/examples/day-in-the-life.md
@@ -14,6 +14,14 @@ Alex opens the workspace folder in their editor. The `/kb` slash command is regi
 Alex: /kb start-day
 
 Agent:
+What I did: Checked Alex's workspace and prepared a read-only morning briefing.
+Where it went: read _kb-tasks/focus.md, _kb-decisions/, team KB pointers, and today's .kb-log.
+Gate notes: n/a — briefing, not capture.
+Suggested next steps:
+  1. Digest @alice's v9 update — may have evidence for D-2026-04-18 (/kb digest team)
+  2. Process leadership feedback (/kb review)
+  3. Message @bob about the progressive-delivery analysis
+
 Good morning. Here's your briefing:
 
 📋 Focus (from _kb-tasks/focus.md):
@@ -49,13 +57,17 @@ Alex reads an interesting paper on coordination protocols, pastes the URL:
 ```
 Alex: /kb https://example.org/papers/coordination-patterns — interesting paper on agent coordination
 
-Agent: [reads paper, applies the evaluation gate]
+Agent: [fetches the paper, applies the evaluation gate]
 
-Captured as finding: _kb-references/findings/2026-04-18-coordination-patterns.md
-Workstream: reliability
-Gate: 4/5 — strengthens deployment-strategy topic, informs D-2026-04-18, actionable, durable signal.
-Decision impact: provides evidence for D-2026-04-18 (coordination model) — supports option (b).
-Added to backlog: "Update deployment-strategy with coordination patterns"
+What I did: Captured the paper as a finding after fetching the external URL.
+Where it went: wrote _kb-references/findings/2026-04-18-coordination-patterns.md, updated the reliability topic, and added one backlog item.
+Gate notes: 4/5 — externally fetched, strengthens deployment-strategy, informs D-2026-04-18, actionable, durable signal.
+Suggested next steps:
+  1. Update the deployment-strategy topic with this evidence (/kb update-topic deployment-strategy)
+  2. Advance decision D-2026-04-18 to "proposed" with this evidence
+  3. Message @alice — this is relevant to their architecture work
+  4. 🎤 Your backlog has "Present governance framework" — want me to draft a presentation?
+
 TL;DR: Paper proposes a 3-phase coordination protocol for multi-agent systems...
 
 💡 Next steps I can help with:
@@ -75,9 +87,9 @@ Agent: Found 1 unprocessed input: _kb-inputs/2026-04-17-leadership-feedback.md
 [applies the gate per item]
 
 • 2026-04-17-leadership-feedback.md
-  Gate: 3/5 — informs product-strategy topic + actionable.
-  Finding: _kb-references/findings/2026-04-17-leadership-feedback-distilled.md
-  Topic update: product-strategy.md (added "leadership wants Q3 focus on error budgets")
+  What I did: Captured and distilled one local input, applied mutation.
+  Where it went: wrote _kb-references/findings/2026-04-17-leadership-feedback-distilled.md and updated product-strategy.md.
+  Gate notes: 3/5 — local-only source, informs product-strategy, actionable.
   TODOs added:
     - Respond to leadership with a one-pager by Thursday
     - Update Q3 product-strategy doc

--- a/docs/examples/first-hour.md
+++ b/docs/examples/first-hour.md
@@ -83,7 +83,7 @@ Check for success: zero literal `{{…}}` placeholders remain anywhere in the sc
 Expected output shape:
 
 ```
-**What I did**: briefed you.
+**What I did**: Checked your personal KB and briefed you, read-only.
 **Where it went**: read focus.md (0 items), _kb-decisions/ (0 items), .kb-log/2026-04-18.log (new), _kb-workstreams/<name>.md.
 **Gate notes**: n/a — briefing, not capture.
 **Suggested next steps**:
@@ -99,7 +99,7 @@ On a clean workspace with no inputs, the briefing is a one-liner "no pending wor
 /kb https://example.com/article-about-caches
 ```
 
-Expected behavior: the skill fetches the URL (or asks for consent first), applies the five-question evaluation gate, writes `_kb-references/findings/2026-04-18-<slug>.md`, possibly updates a workstream's topic file, logs the operation, and ends with 1–3 next steps.
+Expected behavior: the skill fetches the URL (or asks for consent first), says explicitly that it used externally fetched material, applies the five-question evaluation gate, writes `_kb-references/findings/2026-04-18-<slug>.md`, possibly updates a workstream's topic file, logs the operation, and ends with 1–3 next steps that are clearly distinct from changes already applied.
 
 If the URL needs auth or is a PDF, the skill should surface the blocker — not fail silently. If it fails silently, file an issue.
 

--- a/plugins/kb/skills/kb-management/SKILL.md
+++ b/plugins/kb/skills/kb-management/SKILL.md
@@ -189,6 +189,14 @@ Every response follows the same shape:
 3. **Gate notes** — which of the five questions matched (if relevant).
 4. **Suggested next steps** — 1–3 concrete follow-ups.
 
+Additional collaboration-safe requirements:
+
+- Make the action mode obvious: **read-only analysis**, **proposed mutation**, or **applied mutation**.
+- If external material was fetched, say so explicitly.
+- If the action crossed layers (`promote`, `digest`, `publish`), show source and destination clearly.
+- Make uncertainty visible when the gate result is borderline, low-confidence, or partially duplicative.
+- Never blur an already-applied mutation into a mere suggestion, or a suggestion into an applied change.
+
 Keep output terse. The user reads it in a terminal/editor pane, not a full document.
 
 ## Safety rules
@@ -219,5 +227,6 @@ The templates this skill instantiates live in `templates/`:
 - `references/rituals.md` — the four rituals in detail.
 - `references/html-artifacts.md` — presentation/report generation contract.
 - `references/evaluation-gate.md` — the five-question filter, in depth.
+- `references/output-contract.md` — collaboration-safe wording and examples for read-only, proposed, and applied operations.
 
 These files are loaded **only when the specific behavior is invoked**. The skill's top-level instructions are sufficient for most operations.

--- a/plugins/kb/skills/kb-management/references/command-reference.md
+++ b/plugins/kb/skills/kb-management/references/command-reference.md
@@ -116,4 +116,11 @@ Triage is read-only — no mutations, no commits. Output ends with 1–3 concret
 4. Suggested next steps (1-3 concrete follow-ups)
 ```
 
-Keep it terse.
+Collaboration-safe interpretation:
+
+- `What I did` must make the action mode obvious: read-only, proposed, or applied.
+- `Where it went` must distinguish inspected paths from written paths.
+- `Gate notes` must expose external fetches, duplication, and low-confidence judgments when relevant.
+- `Suggested next steps` must stay clearly separate from changes that already happened.
+
+See `output-contract.md` for the full wording contract and examples.

--- a/plugins/kb/skills/kb-management/references/output-contract.md
+++ b/plugins/kb/skills/kb-management/references/output-contract.md
@@ -1,0 +1,216 @@
+# Output Contract — collaboration-safe review
+
+This document defines the response contract for `agentic-kb` operations where humans need to review or trust what an agent did.
+
+The top-level rule stays the same: keep output terse. But terse does not mean ambiguous.
+
+## Required action modes
+
+Every meaningful response must make the operation mode obvious.
+
+### 1. Read-only analysis
+
+Use when the agent inspected state and changed nothing.
+
+Examples:
+- `/kb`
+- `/kb status`
+- `/kb start-day`
+- `/kb diff team`
+- `/kb audit` when no fixes were applied
+
+Required wording signal in **What I did**:
+- `checked`
+- `reviewed`
+- `briefed`
+- `inspected`
+- `compared`
+
+Never use wording that sounds like a file mutation happened.
+
+### 2. Proposed mutation
+
+Use when the agent is recommending a change but has not applied it.
+
+Examples:
+- promotion recommendation
+- suggested topic update
+- suggested decision creation
+- suggested external fetch before consent
+
+Required wording signal in **What I did**:
+- `proposed`
+- `suggested`
+- `prepared`
+- `identified a candidate`
+
+The response must not make the user infer whether the change already happened.
+
+### 3. Applied mutation
+
+Use when files or tracked state actually changed.
+
+Examples:
+- capture wrote a finding
+- digest created a digest finding
+- promote copied material into another layer
+- decision opened or updated
+- task changed
+
+Required wording signal in **What I did**:
+- `captured`
+- `wrote`
+- `updated`
+- `promoted`
+- `digested`
+- `created`
+- `moved`
+
+The response must say where the mutation landed.
+
+## Four required sections
+
+Every normal response still uses the same four sections:
+
+1. **What I did**
+2. **Where it went**
+3. **Gate notes**
+4. **Suggested next steps**
+
+In collaborative contexts, those sections have stricter meaning.
+
+## Section rules
+
+### 1. What I did
+
+Must communicate all of these when relevant:
+
+- action mode: read-only, proposed, or applied,
+- scope: personal, team, org, or marketplace,
+- whether external material was fetched,
+- whether cross-layer movement happened.
+
+Good examples:
+
+- `Checked personal KB status, read-only.`
+- `Proposed a team promotion candidate, no files changed.`
+- `Captured the article as a finding after fetching the URL.`
+- `Digested new team changes into the personal KB and updated VMG.`
+
+### 2. Where it went
+
+For read-only operations, list what was inspected.
+
+For mutations, list exact target paths.
+
+For cross-layer operations, show source and destination clearly enough that a human reviewer can audit the movement.
+
+Good examples:
+
+- `Read alice-kb/.kb-config/layers.yaml and alice-kb/_kb-tasks/focus.md.`
+- `Wrote alice-kb/_kb-references/findings/2026-04-20-cache-paper.md.`
+- `Moved alice-kb/_kb-references/findings/... -> team-kb/alice/_kb-inputs/...`.
+
+### 3. Gate notes
+
+Gate notes must make uncertainty and provenance visible enough for trust.
+
+When relevant, include:
+
+- score or matched questions,
+- whether confidence was low or borderline,
+- whether novelty or duplication was detected,
+- whether the source was local only or externally fetched.
+
+Good examples:
+
+- `4/5, externally fetched, likely durable, overlaps partially with existing topic.`
+- `2/5, local-only, captured as finding only, not strong enough for decision impact.`
+- `n/a, read-only briefing.`
+
+### 4. Suggested next steps
+
+This section must distinguish clearly between:
+
+- actions already applied,
+- actions merely suggested.
+
+Do not list something as a next step if it already happened in the same operation unless the next step is a follow-up form of that action.
+
+Good examples:
+
+- `Promote this finding to team.`
+- `Open a decision from the conflict.`
+- `Refresh HTML overviews.`
+
+Bad example:
+
+- `Capture the article.` when the article was already captured.
+
+## External material rule
+
+If external material was fetched, say so explicitly.
+
+Minimum acceptable disclosure:
+
+- in **What I did**: mention that the URL or external material was fetched,
+- in **Gate notes**: indicate that the judgment used externally fetched content.
+
+If the user has not yet consented to fetch and consent is required by the skill, the response must stay in **proposed mutation** mode until consent is given.
+
+## Cross-layer action rule
+
+For `promote`, `digest`, and `publish`, the response must make layer movement explicit.
+
+Minimum acceptable disclosure:
+
+- source layer,
+- destination layer,
+- whether the action was proposed or applied,
+- the concrete destination path or artifact.
+
+A human reviewer should not need to inspect git diff first to understand what moved where.
+
+## Collaboration-safe examples
+
+### Capture example
+
+```text
+What I did: Captured the article as a personal finding after fetching the URL.
+Where it went: Wrote alice-kb/_kb-references/findings/2026-04-20-cache-paper.md and updated alice-kb/_kb-references/topics/caching.md.
+Gate notes: 4/5, externally fetched, informs an open decision, likely durable, partial overlap with existing caching topic.
+Suggested next steps:
+- Promote this finding to team.
+- Update the related decision with this evidence.
+- Refresh HTML overviews.
+```
+
+### Promote example
+
+```text
+What I did: Promoted one personal finding to the team KB.
+Where it went: Moved alice-kb/_kb-references/findings/2026-04-20-cache-paper.md -> team-kb/alice/_kb-inputs/2026-04-20-cache-paper.md.
+Gate notes: Reused existing gate result, team-relevant, no secret or PII indicators detected.
+Suggested next steps:
+- Ask the team KB to digest the promoted finding.
+- Open a shared decision if the team needs alignment.
+```
+
+### Digest example
+
+```text
+What I did: Digested new team signals into the personal KB, applied mutation.
+Where it went: Read team-kb/alice/_kb-references/findings/... and wrote alice-kb/_kb-references/findings/2026-04-20-team-digest.md; updated alice-kb/_kb-references/foundation/vmg.md.
+Gate notes: Mixed evidence set, local synthesis from team inputs, one unresolved conflict remains between platform and reliability positions.
+Suggested next steps:
+- Open a decision for the unresolved conflict.
+- Review the updated VMG before promoting anything upward.
+```
+
+## Related
+
+- `SKILL.md`
+- `command-reference.md`
+- `../../../../docs/collaboration.md`
+- `../../../../docs/examples/first-hour.md`
+- `../../../../docs/examples/day-in-the-life.md`


### PR DESCRIPTION
## Summary
Strengthens the collaboration-safe response contract for agentic-kb.

## Why
Issue #8 identified that the output contract was too terse to be reliably auditable in shared human collaboration contexts.

## Changes
- add `plugins/kb/skills/kb-management/references/output-contract.md`
- strengthen output semantics in `plugins/kb/skills/kb-management/SKILL.md`
- tighten command-reference wording
- update examples in `docs/examples/first-hour.md` and `docs/examples/day-in-the-life.md`
- link the contract from `README.md`

## Validation
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_plugin_structure.py`
- `npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"`

Closes #8
