### PR TITLE
test: add generate-index simulated-workspace regression

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -85,3 +85,5 @@ jobs:
           python-version: "3.12"
       - name: Validate any checked-in HTML artifacts
         run: python3 scripts/check_html_artifacts.py
+      - name: Regression test generate-index against a simulated workspace
+        run: python3 scripts/test_generate_index.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,14 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ## [Unreleased]
 
+### Added
+
+- **Simulated-workspace regression coverage for `generate-index.py`** (`scripts/test_generate_index.py`, `.github/workflows/validate.yml`) — CI now generates a root artifact index inside a temporary KB and verifies pinned-category ordering, version-family deduplication, referenced-subpage hiding, and dual-theme output.
+
+### Fixed
+
+- **`generate-index.py` self-containment** — removed the external Google Fonts import so generated root artifact indexes stay fully self-contained and comply with the HTML artifact contract.
+
 ## [3.1.0] — 2026-04-20
 
 ### Added

--- a/scripts/generate-index.py
+++ b/scripts/generate-index.py
@@ -623,7 +623,6 @@ def generate_html(artifacts: list[Artifact], title: str, description: str,
 <meta name="generator" content="agentic-kb/generate-index">
 <meta name="generated" content="{now}">
 <style>
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap');
 *, *::before, *::after {{ box-sizing: border-box; margin: 0; padding: 0; }}
 
 :root, [data-theme="dark"] {{
@@ -663,7 +662,8 @@ def generate_html(artifacts: list[Artifact], title: str, description: str,
 }}
 
 html, body {{
-  font-family: 'Inter', system-ui, -apple-system, sans-serif;
+  font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+               'Segoe UI', sans-serif;
   background: var(--bg); color: var(--text);
   line-height: 1.6; -webkit-font-smoothing: antialiased;
 }}

--- a/scripts/test_generate_index.py
+++ b/scripts/test_generate_index.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT = REPO / 'scripts' / 'generate-index.py'
+
+
+ARTIFACT_TEMPLATE = """<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <title>{title}</title>
+  <meta name=\"description\" content=\"{summary}\">
+</head>
+<body>
+  <h1>{title}</h1>
+  <p>{summary}</p>
+  {links}
+</body>
+</html>
+"""
+
+
+def write_html(path: Path, title: str, summary: str, links: str = '') -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        ARTIFACT_TEMPLATE.format(title=title, summary=summary, links=links),
+        encoding='utf-8',
+    )
+
+
+def assert_contains(text: str, needle: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"expected to find {needle!r}")
+
+
+def assert_not_contains(text: str, needle: str) -> None:
+    if needle in text:
+        raise AssertionError(f"did not expect to find {needle!r}")
+
+
+def assert_before(text: str, first: str, second: str) -> None:
+    first_index = text.find(first)
+    second_index = text.find(second)
+    if first_index == -1:
+        raise AssertionError(f"missing marker {first!r}")
+    if second_index == -1:
+        raise AssertionError(f"missing marker {second!r}")
+    if first_index >= second_index:
+        raise AssertionError(f"expected {first!r} before {second!r}")
+
+
+def main() -> int:
+    tempdir = Path(tempfile.mkdtemp(prefix='agentic-kb-index-test-'))
+    try:
+        config_dir = tempdir / '.kb-config'
+        config_dir.mkdir(parents=True, exist_ok=True)
+        (config_dir / 'artifacts.yaml').write_text(
+            """index:
+  pinned-categories:
+    - Journey Maps
+  category-order: recency
+  dedup-versioned: true
+  drop-referenced-subpages: true
+""",
+            encoding='utf-8',
+        )
+
+        write_html(
+            tempdir / '_kb-references' / 'journey-map-2026-04-10.html',
+            'Journey Map',
+            'Pinned category should render before newer report categories.',
+        )
+        write_html(
+            tempdir / '_kb-references' / 'reports' / 'weekly-status-2026-04-18.html',
+            'Weekly Status',
+            'Newer report used to verify pinned categories still come first.',
+        )
+        write_html(
+            tempdir / '_kb-references' / 'reports' / 'strategy-report-v1-2026-04-17.html',
+            'Strategy Report v1',
+            'Older version that should be deduplicated away.',
+        )
+        write_html(
+            tempdir / '_kb-references' / 'reports' / 'strategy-report-v2-2026-04-18.html',
+            'Strategy Report v2',
+            'Newest version that should remain after deduplication.',
+        )
+        write_html(
+            tempdir / '_kb-references' / 'journeys' / 'launch-journey.html',
+            'Launch Journey',
+            'Hub page that links to sub-pages.',
+            '<a href="step-1.html">Step 1</a><a href="step-2.html">Step 2</a>',
+        )
+        write_html(
+            tempdir / '_kb-references' / 'journeys' / 'step-1.html',
+            'Launch Journey Step 1',
+            'Leaf page that should be hidden from the root index.',
+        )
+        write_html(
+            tempdir / '_kb-references' / 'journeys' / 'step-2.html',
+            'Launch Journey Step 2',
+            'Second leaf page that should also be hidden from the root index.',
+        )
+
+        subprocess.run(
+            ['python3', str(SCRIPT), str(tempdir), '--title', 'Simulated KB', '--description', 'Regression test'],
+            check=True,
+            cwd=REPO,
+        )
+
+        output = (tempdir / 'index.html').read_text(encoding='utf-8')
+
+        assert_not_contains(output, '@import url(')
+        assert_not_contains(output, 'fonts.googleapis.com')
+        assert_not_contains(output, '<script src="https://')
+        assert_not_contains(output, '<link rel="stylesheet" href="https://')
+        assert_contains(output, 'data-theme="dark"')
+        assert_contains(output, '[data-theme="light"]')
+
+        assert_before(output, '<h2>Journey Maps', '<h2>Reports')
+        assert_contains(output, 'strategy-report-v2-2026-04-18.html')
+        assert_not_contains(output, 'strategy-report-v1-2026-04-17.html')
+        assert_contains(output, 'launch-journey.html')
+        assert_not_contains(output, 'step-1.html')
+
+        print('generate-index regression test: OK')
+        return 0
+    finally:
+        shutil.rmtree(tempdir)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
Adds a simulated-workspace regression check for `scripts/generate-index.py` and fixes one contract violation it surfaced.

## Type of change
- [ ] Spec edit (concept or spec doc)
- [ ] Reference implementation (skill, agent, plugin, generator, installer)
- [x] CI / tooling
- [ ] Docs / examples / glossary
- [ ] Other:

## Version bump
- [x] No bump required (CI / internal-only)
- [ ] PATCH (prose edits, typos, clarifications)
- [ ] MINOR (new rules, new commands, additive changes)
- [ ] MAJOR (breaking changes to layout, commands, or file formats)

## Checklist
- [ ] Per-file `## Changelog` appended for every modified long-lived spec/concept doc
- [x] Root `CHANGELOG.md` updated under `## [Unreleased]`
- [ ] `VERSION` bumped if the change is user-visible
- [ ] Links validated locally (`lychee --config .lychee.toml .`)
- [x] `python3 scripts/check_consistency.py` passes
- [x] `python3 scripts/check_plugin_structure.py` passes (if skills/agents/plugins touched)
- [ ] Plugin generator has been run (`python3 scripts/generate_plugins.py`) and the result is committed (if skills/agents/plugin index touched)
- [x] No vendor-specific terms introduced

## Related
- Follows open issue #8 and docs PR #11 with tooling coverage for the collaboration and self-contained artifact contract.
- Advances roadmap item: walk-through tests against a simulated workspace.

## Validation
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_plugin_structure.py`
- `python3 scripts/check_html_artifacts.py`
- `python3 scripts/test_generate_index.py`