### PR TITLE
fix: restore missing idea.md scaffold template

### DIFF
--- a/plugins/kb/skills/kb-management/templates/idea.md
+++ b/plugins/kb/skills/kb-management/templates/idea.md
@@ -1,0 +1,20 @@
+# Idea: {{TITLE}}
+
+**Stage**: {{STAGE}}
+**Created**: {{CREATED}}
+**Workstream**: {{WORKSTREAM}}
+**Sparring rounds**: {{SPARRING_ROUNDS}}
+
+## Seed
+
+{{SEED}}
+
+## Development Log
+
+| Date | What | Trigger |
+|------|------|---------|
+{{DEVELOPMENT_LOG}}
+
+## Connections
+
+{{CONNECTIONS}}


### PR DESCRIPTION
## Summary
Salvages the real product improvement from closed PR #36 without carrying over the noisy test-report path. Restores the missing `idea.md` scaffold template referenced by `kb-management`.

## Validation
- python3 scripts/check_consistency.py
- python3 scripts/check_plugin_structure.py
- npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"

Fixes #33