### PR TITLE
fix: wire **Maturity**: into capture flow, triage, and audit K1 (#14, #31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
+- **`**Maturity**:` never written on findings/topics** — added the field to `finding.md` and `topic.md` templates, wired the capture flow in `kb-management/SKILL.md` to set it from the gate outcome, and aligned the triage signal (`kb.prompt.md`, `command-reference.md`) and audit rule K1 (`audit.md`) to read the same bold-bullet form. Fixes the broken `capture → promote` surfacing loop (#14, #31).
 - **Missing `idea.md` scaffold template** — restored `plugins/kb/skills/kb-management/templates/idea.md` so `/kb idea` has a canonical file source again, matching the behavioral spec and REFERENCE docs.
 - **`/kb setup` scaffold source ambiguity** — clarified in `plugins/kb/skills/kb-setup/SKILL.md` which personal-KB scaffold files come from `kb-setup/templates/` versus `kb-management/templates/`, so implementers no longer have to guess across two directories.
 - **Residual vendor-neutrality cleanup** — removed the last internal-specific residue from the public spec by replacing an internal example label in `kb-roadmap` adapter docs and generalizing a changelog note that still exposed a vendor-prefixed token pattern.

--- a/plugins/kb/skills/kb-management/SKILL.md
+++ b/plugins/kb/skills/kb-management/SKILL.md
@@ -79,6 +79,8 @@ Full command reference: `references/command-reference.md`.
    5. Does this already exist?
    Score 0 → discard + log `skipped` with rationale. Score 1–2 → finding only (offer idea creation if novelty detected). Score 3+ → finding + topic update + possibly new decision or idea.
 
+   **Set `**Maturity**:` from the gate outcome** when writing the finding/topic: score 1–2 → `raw`; score 3+ → `emerging`. Only promote to `durable` on explicit user confirmation ("this is ready to share") or when a second corroborating capture lands. The `Promotions due` triage signal and audit rule K1 read this field — never leave it blank.
+
 1b. **Check strategic alignment** when VMG is declared in `_kb-references/foundation/vmg.md`. Material aligned with active goals gets +1. Material contradicting a goal is captured + flagged for decision review.
 
 2. **Always suggest next steps.** Every operation output ends with 1–3 concrete follow-ups (promote, notify, update topic, generate presentation).
@@ -256,6 +258,7 @@ These files are loaded **only when the specific behavior is invoked**. The skill
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-04-22 | Wired `**Maturity**:` into the capture flow so bare `/kb` triage and audit K1 can read the field they were designed for | Fixes #14 + #31 |
 | 2026-04-22 | Restored the missing `idea.md` scaffold template so `/kb idea` has a canonical file source again | System test follow-up |
 | 2026-04-22 | Version aligned to 3.4.0 after documenting Codex CLI compatibility in the public setup/onboarding contract | Compatibility expansion |
 | 2026-04-22 | `/kb promote` now performs destination-layer review for local team KBs instead of stopping at the team inbox; version bumped to 3.3.0 | Team promote flow fix |

--- a/plugins/kb/skills/kb-management/references/audit.md
+++ b/plugins/kb/skills/kb-management/references/audit.md
@@ -13,7 +13,7 @@ KB-wide consistency audit. Runs the foundational checks directly, then delegates
 
 | # | Rule | Violation class | Correction offered |
 |---|------|----------------|---------------------|
-| K1 | Every finding has a `maturity:` marker (`raw` / `emerging` / `durable`) | `finding-maturity-missing` | Propose classification from content |
+| K1 | Every finding and topic has a `**Maturity**:` line (`raw` / `emerging` / `durable`) | `maturity-missing` | Propose classification from content |
 | K2 | Every `durable` finding is referenced from at least one topic | `durable-finding-orphan` | Offer to cite it in the closest-matching topic |
 | K3 | Every topic's `sources.md` entries resolve to existing files or URLs | `broken-source` | Offer removal or update |
 | K4 | Every decision (`_kb-decisions/D-*.md`) has a `status:` and — if resolved — a resolution date | `decision-status-missing` | Prompt for status |

--- a/plugins/kb/skills/kb-management/references/command-reference.md
+++ b/plugins/kb/skills/kb-management/references/command-reference.md
@@ -94,7 +94,7 @@ When `/kb` is invoked with no argument, report a read-only consolidated status. 
 | Overdue todos | `_kb-tasks/*.md` with status `todo`/`doing` > 7 days |
 | Rituals | Today's `.kb-log/YYYY-MM-DD.log` missing `start-day`; current week missing `start-week` |
 | Upstream digest drift | L2/L3 HEAD differs from `_kb-references/strategy-digests/.last-digest` (or per-repo watermark) |
-| Promotions due | `maturity: durable` findings/topics not yet referenced in L2/L3 |
+| Promotions due | `**Maturity**: durable` findings/topics not yet referenced in L2/L3 |
 | Stale topics | Topics unchanged > 60 days but still cited by recent findings |
 
 Triage is read-only — no mutations, no commits. Output ends with 1–3 concrete next steps.

--- a/plugins/kb/skills/kb-management/templates/finding.md
+++ b/plugins/kb/skills/kb-management/templates/finding.md
@@ -4,6 +4,7 @@
 **Workstream**: {{WORKSTREAM}}
 **Source**: {{SOURCE}}
 **Gate**: {{GATE_SCORE}} ({{GATE_NOTES}})
+**Maturity**: {{MATURITY}}
 
 ## TL;DR
 

--- a/plugins/kb/skills/kb-management/templates/topic.md
+++ b/plugins/kb/skills/kb-management/templates/topic.md
@@ -1,5 +1,6 @@
 # Topic: {{TITLE}}
 
+**Maturity**: {{MATURITY}}
 **External anchors**:
 {{EXTERNAL_ANCHORS}}
 

--- a/plugins/kb/skills/kb-setup/SKILL.md
+++ b/plugins/kb/skills/kb-setup/SKILL.md
@@ -328,6 +328,7 @@ Every placeholder below has exactly one source — always from the interview ans
 | `{{KEYWORD_LOOKUP}}` | Computed — `docs/glossary.md` summary injected verbatim |
 | `{{RECENT_REPORTS}}` | Empty `<ul></ul>` on first run (will be filled by `/kb present` / `/kb report`) |
 | `{{DATE}}` | Today's ISO-8601 date (`YYYY-MM-DD`) |
+| `{{MATURITY}}` | `raw` for the initial topic-stub scaffold (empty positions). Findings written later by `/kb` capture set it from the gate outcome — see `kb-management/SKILL.md` rule 1. |
 | `{{VERSION}}` | `1.0` on first scaffold; later artifacts bump their own version |
 | `{{BRAND_NAME}}` | Q13 — adopter brand display name (defaults to `{{KB_NAME}}` when not set) |
 | `{{CONFIDENTIAL_LABEL}}` | Q13 — e.g. `Confidential`, `Internal`, or empty string to hide |

--- a/plugins/kb/skills/kb-setup/templates/kb.prompt.md
+++ b/plugins/kb/skills/kb-setup/templates/kb.prompt.md
@@ -48,7 +48,7 @@ When the user invokes `/kb` with no argument, scan the workspace and report a si
 | Overdue focus | `_kb-tasks/focus.md` items with status `doing` > 7 days | Surface so user can re-plan |
 | Rituals overdue | Today's `.kb-log/YYYY-MM-DD.log` missing a `start-day` entry; current week missing `start-week` | Suggest the missing ritual |
 | Upstream digest drift | L2/L3 repos declared in `layers.yaml` whose HEAD commit differs from the watermark in `_kb-references/strategy-digests/.last-digest` (or equivalent per repo) | Suggest `/kb digest <layer>` |
-| Promotions due | Findings/topics with `maturity: durable` in frontmatter not yet referenced in any L2/L3 KB | Suggest `/kb promote <file>` |
+| Promotions due | Findings/topics declaring `**Maturity**: durable` not yet referenced in any L2/L3 KB | Suggest `/kb promote <file>` |
 | Stale topics | Topics unchanged > 60 days and still referenced by recent findings | Suggest `/kb audit` |
 
 Output shape:


### PR DESCRIPTION
## Summary

Closes #14, closes #31.

The capture→promote loop was broken end-to-end: `finding.md` and
`topic.md` templates never emitted a `**Maturity**:` line, yet the
bare-`/kb` triage scan looked for `maturity: durable` and audit K1
required the same field. Result: every system-created finding failed
K1, and no fresh capture ever surfaced as a promote candidate.

## Changes

- **Templates**: `finding.md` + `topic.md` now emit `**Maturity**: {{MATURITY}}`.
- **Capture flow** (`kb-management/SKILL.md` rule 1): set the field
  from the gate outcome — `1–2 → raw`, `3+ → emerging`. `durable`
  requires explicit user confirmation or a corroborating second capture.
- **Setup scaffold** (`kb-setup/SKILL.md` placeholder table): default
  `{{MATURITY}}` to `raw` for initial topic stubs.
- **Triage + audit alignment**: `kb.prompt.md`, `command-reference.md`
  triage, and `audit.md` K1 all now read the same bold-bullet form
  (`**Maturity**: durable`), matching the templates.

## Self-review notes

- Initial draft mapped score 5 → `durable` automatically. Corrected:
  `durable` is a quality of settled, referenced content — not an
  instantaneous post-capture state. Now it requires user confirmation
  or a second corroborating capture (tracks issue #14's proposal).
- K1 scope extended from "Every finding" to "Every finding and topic"
  since topics now carry the field too.
- Violation class renamed `finding-maturity-missing` → `maturity-missing`
  since K1 now covers topics too. No downstream tooling references the
  old name (the check was previously unusable).

## Test plan

- [x] `check_consistency.py` — OK
- [x] `check_plugin_structure.py` — OK (4 skills, 1 agent)
- [x] `test_generate_index.py` — OK
- [x] `markdownlint-cli2` — 0 errors
- [x] `generate_plugins.py` — no drift

https://claude.ai/code/session_019DhHEZEiMAPidLpCV1nbPL