### PR TITLE
fix: align open-decisions triage and audit K4 with decision template (#15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 ### Fixed
 
 - **`**Maturity**:` never written on findings/topics** — added the field to `finding.md` and `topic.md` templates, wired the capture flow in `kb-management/SKILL.md` to set it from the gate outcome, and aligned the triage signal (`kb.prompt.md`, `command-reference.md`) and audit rule K1 (`audit.md`) to read the same bold-bullet form. Fixes the broken `capture → promote` surfacing loop (#14, #31).
+- **Open-decisions triage signal never fires** — aligned the `/kb` triage rule and audit K4 to read the decision template's `**Status**:` bold-bullet form instead of a non-existent `status: proposed` YAML frontmatter. Triage now counts open decisions as files under `_kb-decisions/` whose status is not `resolved` / `superseded` / `dropped`. Fixes #15.
 - **Missing `idea.md` scaffold template** — restored `plugins/kb/skills/kb-management/templates/idea.md` so `/kb idea` has a canonical file source again, matching the behavioral spec and REFERENCE docs.
 - **`/kb setup` scaffold source ambiguity** — clarified in `plugins/kb/skills/kb-setup/SKILL.md` which personal-KB scaffold files come from `kb-setup/templates/` versus `kb-management/templates/`, so implementers no longer have to guess across two directories.
 - **Residual vendor-neutrality cleanup** — removed the last internal-specific residue from the public spec by replacing an internal example label in `kb-roadmap` adapter docs and generalizing a changelog note that still exposed a vendor-prefixed token pattern.

--- a/plugins/kb/skills/kb-management/SKILL.md
+++ b/plugins/kb/skills/kb-management/SKILL.md
@@ -259,6 +259,7 @@ These files are loaded **only when the specific behavior is invoked**. The skill
 | Date | What changed | Source |
 |------|-------------|--------|
 | 2026-04-22 | Wired `**Maturity**:` into the capture flow so bare `/kb` triage and audit K1 can read the field they were designed for | Fixes #14 + #31 |
+| 2026-04-22 | Aligned open-decisions triage + audit K4 to read the template's `**Status**:` bold-bullet form so `/kb` triage finally counts open decisions | Fixes #15 |
 | 2026-04-22 | Restored the missing `idea.md` scaffold template so `/kb idea` has a canonical file source again | System test follow-up |
 | 2026-04-22 | Version aligned to 3.4.0 after documenting Codex CLI compatibility in the public setup/onboarding contract | Compatibility expansion |
 | 2026-04-22 | `/kb promote` now performs destination-layer review for local team KBs instead of stopping at the team inbox; version bumped to 3.3.0 | Team promote flow fix |

--- a/plugins/kb/skills/kb-management/references/audit.md
+++ b/plugins/kb/skills/kb-management/references/audit.md
@@ -16,7 +16,7 @@ KB-wide consistency audit. Runs the foundational checks directly, then delegates
 | K1 | Every finding and topic has a `**Maturity**:` line (`raw` / `emerging` / `durable`) | `maturity-missing` | Propose classification from content |
 | K2 | Every `durable` finding is referenced from at least one topic | `durable-finding-orphan` | Offer to cite it in the closest-matching topic |
 | K3 | Every topic's `sources.md` entries resolve to existing files or URLs | `broken-source` | Offer removal or update |
-| K4 | Every decision (`_kb-decisions/D-*.md`) has a `status:` and — if resolved — a resolution date | `decision-status-missing` | Prompt for status |
+| K4 | Every decision (`_kb-decisions/D-*.md`) has a `**Status**:` line and — if `resolved` — a resolution date in the evidence trail | `decision-status-missing` | Prompt for status |
 | K5 | Every idea (`_kb-ideas/I-*.md`) has a `status:` marker | `idea-status-missing` | Prompt for status |
 | K6 | No pending inputs older than `freshness.inputs-days` without being triaged | `stale-input` | Offer triage now |
 | K7 | Foundation files present: `me.md`, `context.md`, `vmg.md`, `sources.md`, `naming.md` | `foundation-incomplete` | Offer scaffold |
@@ -84,7 +84,7 @@ The KB-wide audit composes over the primitive-skill resolution commands — it d
 - `/kb decide resolve <id>` for incomplete decisions
 - Inline `accept | defer | suppress` for KB-wide violations that don't need further routing
 
-Every resolution respects the existing safety gates (tracker writes need `--apply`; config edits get diff previews; decisions route to `_kb-decisions/` with `status: proposed`).
+Every resolution respects the existing safety gates (tracker writes need `--apply`; config edits get diff previews; decisions route to `_kb-decisions/` with `**Status**: gathering-evidence` per the template default).
 
 ## Exit codes
 

--- a/plugins/kb/skills/kb-management/references/command-reference.md
+++ b/plugins/kb/skills/kb-management/references/command-reference.md
@@ -90,7 +90,7 @@ When `/kb` is invoked with no argument, report a read-only consolidated status. 
 |---|---|
 | Setup complete? | `.kb-config/layers.yaml` exists |
 | Pending inputs | `_kb-inputs/` not yet in `_kb-inputs/digested/` |
-| Open decisions | `_kb-decisions/*.md` with `status: proposed` |
+| Open decisions | `_kb-decisions/*.md` (not in `archive/`) whose `**Status**:` is not `resolved` / `superseded` / `dropped` |
 | Overdue todos | `_kb-tasks/*.md` with status `todo`/`doing` > 7 days |
 | Rituals | Today's `.kb-log/YYYY-MM-DD.log` missing `start-day`; current week missing `start-week` |
 | Upstream digest drift | L2/L3 HEAD differs from `_kb-references/strategy-digests/.last-digest` (or per-repo watermark) |

--- a/plugins/kb/skills/kb-roadmap/references/audit.md
+++ b/plugins/kb/skills/kb-roadmap/references/audit.md
@@ -98,7 +98,7 @@ All resolution actions follow the existing safety gates:
 - Tracker writes require `--apply` + interactive confirmation.
 - Journey reviews transition into `/kb journeys review --from-finding <file>`.
 - Config edits produce a diff preview before writing.
-- Decision entries route to `_kb-decisions/D-<date>-<slug>.md` with `status: proposed`.
+- Decision entries route to `_kb-decisions/D-<date>-<slug>.md` with `**Status**: gathering-evidence` per the decision template default.
 
 ## Resume routing integration
 

--- a/plugins/kb/skills/kb-setup/templates/kb.prompt.md
+++ b/plugins/kb/skills/kb-setup/templates/kb.prompt.md
@@ -43,7 +43,7 @@ When the user invokes `/kb` with no argument, scan the workspace and report a si
 | **Top task** | First item in `_kb-tasks/focus.md` (if any) | Always include as `Next up: …` |
 | **External completions** | Open focus/backlog tasks with evidence of closure (merged PR / closed Jira ticket / commit referencing the task slug / same slug already in a shared `_kb-tasks/archive/`). See SKILL.md rule #10c. | Propose archiving — never auto-close |
 | Pending inputs | Files under `_kb-inputs/` not yet in `_kb-inputs/digested/` | Count + suggest `/kb review` |
-| Open decisions | Files under `_kb-decisions/` with `status: proposed` in frontmatter | Count + suggest `/kb decide <key>` |
+| Open decisions | Files under `_kb-decisions/` (not in `archive/`) whose `**Status**:` is not `resolved` / `superseded` / `dropped` | Count + suggest `/kb decide <key>` |
 | Stale tasks | `_kb-tasks/backlog.md` items untouched > 14 days | Annotate `stale: true`; list but don't remove |
 | Overdue focus | `_kb-tasks/focus.md` items with status `doing` > 7 days | Surface so user can re-plan |
 | Rituals overdue | Today's `.kb-log/YYYY-MM-DD.log` missing a `start-day` entry; current week missing `start-week` | Suggest the missing ritual |


### PR DESCRIPTION
## Summary

Closes #15.

The `/kb` triage scan looked for `status: proposed` in YAML frontmatter,
but the decision template writes `- **Status**: gathering-evidence` as
a markdown bullet. Format and vocabulary both mismatched — every fresh
decision was a silent zombie invisible to triage.

## Changes

- **Triage** (`kb.prompt.md`, `command-reference.md`): count files under
  `_kb-decisions/` (not in `archive/`) whose `**Status**:` is not
  `resolved` / `superseded` / `dropped`.
- **Audit K4** (`audit.md`): read the same bold-bullet form.
- **Copy-edit** (`audit.md`, `kb-roadmap/references/audit.md`): the "new
  decisions route to `status: proposed`" prose aligned to the template
  default (`gathering-evidence`).

Keeps the template unchanged — spec and template now agree.

## Self-review notes

- Considered adding YAML frontmatter to `decision.md` for
  machine-readability, but that's a larger breaking change. The
  bold-bullet form is already consistent with `**Date**:`,
  `**Source**:` etc. across findings/topics (and now `**Maturity**:`
  from #43).
- Idea template uses `**Stage**:` not `**Status**:` — that's a
  separate conflict tracked in #35, out of scope here.

## Test plan

- [x] `check_consistency.py` — OK
- [x] `check_plugin_structure.py` — OK
- [x] `markdownlint-cli2` — 0 errors
- [x] `generate_plugins.py` — no manifest drift

https://claude.ai/code/session_019DhHEZEiMAPidLpCV1nbPL