### PR TITLE
Fix installer drift detection for copied installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
+- **`scripts/install.py` drift detection** — existing installs now compare source and installed front-matter `version:` values for skills and agents before skipping. Re-runs report `up-to-date` when versions match, `stale (old -> new)` when a copied install is behind, and the generic `skip (exists)` path now tells adopters to rerun with `--force` to reinstall/update. Fixes #29.
 - **Evaluation gate Q5 polarity and scoring examples** — `kb-management` now frames Q5 as "materially new compared to existing topics", defines the numeric score as the count of yes answers across Q1-Q5, removes the obsolete VMG `+1` bonus from the normative summaries, and fixes the worked examples/log wording. Fixes #30.
 - **`**Maturity**:` never written on findings/topics** — added the field to `finding.md` and `topic.md` templates, wired the capture flow in `kb-management/SKILL.md` to set it from the gate outcome, and aligned the triage signal (`kb.prompt.md`, `command-reference.md`) and audit rule K1 (`audit.md`) to read the same bold-bullet form. Fixes the broken `capture → promote` surfacing loop (#14, #31).
 - **Open-decisions triage signal never fires** — aligned the `/kb` triage rule and audit K4 to read the decision template's `**Status**:` bold-bullet form instead of a non-existent `status: proposed` YAML frontmatter. Triage now counts open decisions as files under `_kb-decisions/` whose status is not `resolved` / `superseded` / `dropped`. Fixes #15.

--- a/scripts/install.py
+++ b/scripts/install.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -59,6 +60,7 @@ REPO = Path(__file__).resolve().parent.parent
 VSCODE_PLUGIN_JSON = REPO / "plugin.json"
 
 IS_WINDOWS = os.name == "nt"
+VERSION_LINE_RE = re.compile(r"^version:\s*([^\s]+)\s*$")
 
 
 def discover_skill_agent_paths(pj: dict) -> tuple[dict[str, Path], dict[str, Path]]:
@@ -118,10 +120,95 @@ def detect_targets() -> list[str]:
     return hits or ["claude"]
 
 
+def read_frontmatter_version(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        return None
+    if not lines or lines[0].strip() != "---":
+        return None
+    for line in lines[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            return None
+        match = VERSION_LINE_RE.match(stripped)
+        if match:
+            return match.group(1).strip("\"'")
+    return None
+
+
+def versioned_artifact_path(path: Path) -> Path | None:
+    if path.is_symlink():
+        try:
+            path = path.resolve(strict=True)
+        except FileNotFoundError:
+            return None
+    elif not path.exists():
+        return None
+    if path.is_dir():
+        skill_doc = path / "SKILL.md"
+        return skill_doc if skill_doc.is_file() else None
+    if path.is_file() and path.suffix.lower() == ".md":
+        return path
+    return None
+
+
+def artifact_version(path: Path) -> str | None:
+    doc = versioned_artifact_path(path)
+    if doc is None:
+        return None
+    return read_frontmatter_version(doc)
+
+
+def parse_version(version: str | None) -> tuple[int, ...] | None:
+    if version is None:
+        return None
+    parts = version.split(".")
+    if not parts or any(not part.isdigit() for part in parts):
+        return None
+    return tuple(int(part) for part in parts)
+
+
+def compare_versions(left: str | None, right: str | None) -> int | None:
+    left_parts = parse_version(left)
+    right_parts = parse_version(right)
+    if left_parts is None or right_parts is None:
+        return None
+    width = max(len(left_parts), len(right_parts))
+    left_padded = left_parts + (0,) * (width - len(left_parts))
+    right_padded = right_parts + (0,) * (width - len(right_parts))
+    if left_padded > right_padded:
+        return 1
+    if left_padded < right_padded:
+        return -1
+    return 0
+
+
 def link_or_copy(src: Path, dst: Path, force: bool) -> None:
     if dst.exists() or dst.is_symlink():
         if not force:
-            print(f"  skip (exists): {dst}")
+            src_version = artifact_version(src)
+            dst_version = artifact_version(dst)
+            version_cmp = compare_versions(src_version, dst_version)
+            if version_cmp == 0 and src_version is not None:
+                print(f"  up-to-date (v{src_version}): {dst}")
+            elif version_cmp == 1 and dst_version is not None and src_version is not None:
+                print(
+                    f"  stale (v{dst_version} -> v{src_version}): {dst} "
+                    "(run with --force to reinstall / update)"
+                )
+            elif version_cmp == -1 and dst_version is not None and src_version is not None:
+                print(
+                    f"  newer installed (v{dst_version} > v{src_version}): {dst} "
+                    "(run with --force to reinstall / downgrade)"
+                )
+            else:
+                print(
+                    f"  skip (exists): {dst} "
+                    "(run with --force to reinstall / update)"
+                )
             return
         if dst.is_dir() and not dst.is_symlink():
             shutil.rmtree(dst)

--- a/scripts/test_install.py
+++ b/scripts/test_install.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import contextlib
+import importlib.util
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).with_name("install.py")
+SPEC = importlib.util.spec_from_file_location("agentic_kb_install", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+install = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(install)
+
+
+def write_skill(path: Path, version: str) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "SKILL.md").write_text(
+        "\n".join(
+            [
+                "---",
+                "name: sample-skill",
+                f"version: {version}",
+                "---",
+                "",
+                "# Sample",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+class InstallDriftDetectionTests(unittest.TestCase):
+    def test_existing_copy_reports_up_to_date_when_versions_match(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "src-skill"
+            dst = root / "dst-skill"
+            write_skill(src, "1.2.3")
+
+            original_is_windows = install.IS_WINDOWS
+            install.IS_WINDOWS = True
+            try:
+                install.link_or_copy(src, dst, force=False)
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    install.link_or_copy(src, dst, force=False)
+            finally:
+                install.IS_WINDOWS = original_is_windows
+
+            self.assertIn(f"up-to-date (v1.2.3): {dst}", buf.getvalue())
+
+    def test_existing_copy_reports_stale_and_keeps_old_contents(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "src-skill"
+            dst = root / "dst-skill"
+            write_skill(src, "1.0.0")
+
+            original_is_windows = install.IS_WINDOWS
+            install.IS_WINDOWS = True
+            try:
+                install.link_or_copy(src, dst, force=False)
+                write_skill(src, "1.1.0")
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    install.link_or_copy(src, dst, force=False)
+            finally:
+                install.IS_WINDOWS = original_is_windows
+
+            self.assertIn(
+                f"stale (v1.0.0 -> v1.1.0): {dst} (run with --force to reinstall / update)",
+                buf.getvalue(),
+            )
+            self.assertIn("version: 1.0.0", (dst / "SKILL.md").read_text(encoding="utf-8"))
+
+    def test_unversioned_existing_file_prints_force_tip(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            src = root / "kb.prompt.md"
+            dst = root / "installed.prompt.md"
+            src.write_text("# Prompt\n", encoding="utf-8")
+
+            original_is_windows = install.IS_WINDOWS
+            install.IS_WINDOWS = True
+            try:
+                install.link_or_copy(src, dst, force=False)
+                buf = io.StringIO()
+                with contextlib.redirect_stdout(buf):
+                    install.link_or_copy(src, dst, force=False)
+            finally:
+                install.IS_WINDOWS = original_is_windows
+
+            self.assertIn(
+                f"skip (exists): {dst} (run with --force to reinstall / update)",
+                buf.getvalue(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- detect version drift in `scripts/install.py` before the existing `skip (exists)` early return
- report `up-to-date` for matching installs and `stale (old -> new)` for copied installs that need `--force`
- add regression coverage for copied and unversioned installs

## Validation
- `python3 -m unittest scripts/test_install.py`
- `python3 scripts/check_consistency.py`
- `python3 scripts/check_plugin_structure.py`
- `python3 scripts/check_html_artifacts.py`
- `npx markdownlint-cli2 "docs/**/*.md" "*.md"`

`lychee --config .lychee.toml .` was attempted but `lychee` is not installed in the local environment.