### PR TITLE
docs: fill in missing placeholders in kb-setup mapping table (#20)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
+- **Placeholder mapping table completeness** — `kb-setup/SKILL.md` §Templates now declares `{{WORKSPACE_ROOT}}` (Q4), `{{ALIAS_INDEX}}` (computed), and the five workstream-stub placeholders (`{{ACTIVE_DECISIONS}}`, `{{KEY_TOPICS}}`, `{{CURRENT_STATE}}`, `{{ACTIVE_THREADS}}`, `{{DEPENDENCIES}}`) so the post-write `{{…}}` gate no longer forces agents to improvise or silently block Step 8. Fixes #20.
 - **Version metadata and shipped dashboard copy aligned for v3.4.3** — `README.md` now advertises `spec-v3.4.3`, the root/plugin/Claude marketplace manifests now all report `3.4.3`, and the shipped `kb-management` `index.html` template describes `dashboard.html` as including live topics. Follow-up for PR #54.
 - **Dashboard topics visibility** — `scripts/generate-dashboard.py` now renders a dedicated `topics` panel from `_kb-references/topics/`, the default `artifacts.yaml` dashboard panel list includes it, and the dashboard contract docs (`docs/REFERENCE.md`, `kb-management`, `kb-operator`, `html-artifacts.md`) now describe topics as first-class live dashboard state. Fixes #22.
 - **Version metadata aligned for the phantom-overview fix** — bumped `plugins/kb/skills/kb-management/SKILL.md` from `3.4.1` to `3.4.2` and `plugins/kb/agents/kb-operator.md` from `3.4.0` to `3.4.2` so the shipped behavioral change is versioned under the current framework patch release.

--- a/plugins/kb/skills/kb-setup/SKILL.md
+++ b/plugins/kb/skills/kb-setup/SKILL.md
@@ -329,6 +329,10 @@ Every placeholder below has exactly one source — always from the interview ans
 | `{{RECENT_REPORTS}}` | Empty `<ul></ul>` on first run (will be filled by `/kb present` / `/kb report`) |
 | `{{DATE}}` | Today's ISO-8601 date (`YYYY-MM-DD`) |
 | `{{MATURITY}}` | `raw` for the initial topic-stub scaffold (empty positions). Findings written later by `/kb` capture set it from the gate outcome — see `kb-management/SKILL.md` rule 1. |
+| `{{WORKSPACE_ROOT}}` | Q4 — absolute workspace path (default: current directory). Used in `.kb-config/layers.yaml`. |
+| `{{ALIAS_INDEX}}` | Computed — one row per configured workspace alias (short-alias table described at §Workspace-level configuration). Used in workspace-root `AGENTS.md`. |
+| `{{ACTIVE_DECISIONS}}`, `{{KEY_TOPICS}}`, `{{ACTIVE_THREADS}}`, `{{DEPENDENCIES}}` | Empty placeholder literal `(none yet)` on first scaffold (these workstream fields accrete as `/kb` captures and decisions land). Used in `kb-management/templates/workstream.md`. |
+| `{{CURRENT_STATE}}` | `TBD — first briefing via /kb start-day` on first scaffold. The first `start-day` ritual replaces it with the current state summary. Used in `kb-management/templates/workstream.md`. |
 | `{{VERSION}}` | `1.0` on first scaffold; later artifacts bump their own version |
 | `{{BRAND_NAME}}` | Q13 — adopter brand display name (defaults to `{{KB_NAME}}` when not set) |
 | `{{CONFIDENTIAL_LABEL}}` | Q13 — e.g. `Confidential`, `Internal`, or empty string to hide |
@@ -361,6 +365,7 @@ A zero-hit run is the gate for Step 8.
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-04-22 | Placeholder mapping table now declares `{{WORKSPACE_ROOT}}`, `{{ALIAS_INDEX}}`, and the five workstream-stub placeholders (`{{ACTIVE_DECISIONS}}`, `{{KEY_TOPICS}}`, `{{CURRENT_STATE}}`, `{{ACTIVE_THREADS}}`, `{{DEPENDENCIES}}`) so strict post-write-gate runs no longer fall back on improvisation or block the commit | Fixes #20 |
 | 2026-04-22 | Bumped declared skill version to 3.4.1 so the placeholder-gate behavior change ships under the current framework patch version | Version alignment |
 | 2026-04-22 | Post-write placeholder gate now exempts `presentation-template.html` (and its branded sibling) because its `{{…}}` markers are deliberately deferred for `/kb present` — setup Step 8 no longer blocks on the shipped template | Fixes #17 |
 | 2026-04-22 | Clarified which personal-KB scaffold files come from `kb-setup` templates versus `kb-management` templates and required setup to stop explicitly if a referenced template file is missing | Scaffold source contract |


### PR DESCRIPTION
## Summary

Closes #20.

`kb-setup/SKILL.md` §Templates stated every placeholder has exactly
one source listed in the mapping table, but seven were absent:

- `{{WORKSPACE_ROOT}}` (used in `templates/layers.yaml`)
- `{{ALIAS_INDEX}}` (used in `templates/workspace-AGENTS.md`)
- `{{ACTIVE_DECISIONS}}`, `{{KEY_TOPICS}}`, `{{CURRENT_STATE}}`,
  `{{ACTIVE_THREADS}}`, `{{DEPENDENCIES}}` (used in the workstream.md
  scaffold stub)

Strict agents following the "never leave a literal `{{…}}`" rule
would block Step 8 on every first run.

## Changes

Added all seven to the mapping table with concrete scaffold values:

- `{{WORKSPACE_ROOT}}` → Q4 (absolute workspace path; default = current dir).
- `{{ALIAS_INDEX}}` → Computed (one row per configured workspace alias).
- Four list fields → literal `(none yet)` on first scaffold — accrete
  naturally as `/kb` captures and decisions land.
- `{{CURRENT_STATE}}` → "TBD — first briefing via /kb start-day" on
  first scaffold; replaced by the first ritual run.

## Self-review notes

- Audited every `{{…}}` token in the scaffolded templates against the
  mapping table. The remaining tokens (`TITLE`, `WORKSTREAM`, `STAGE`,
  etc.) are filled by `/kb` commands at runtime (capture, idea, decide,
  present) — setup does not substitute them, so they belong in the
  runtime-fill rows already covered by the table (`{{PRESENTATION_TITLE}}`
  style).
- `{{NAME}}` / `{{THEMES}}` in `workstream.md` are per-instance fields
  that setup's workstream-loop binds from `{{WORKSTREAM_N_NAME}}` /
  `{{WORKSTREAM_N_THEMES}}` (already in the table).
- Audit rule K9 checks workstream "current status" isn't TBD. A fresh
  scaffold deliberately trips K9, which directs the user to run
  `/kb start-day` — healthy onboarding signal, not a bug.

## Test plan

- [x] `check_consistency.py` — OK
- [x] `check_plugin_structure.py` — OK
- [x] `test_generate_index.py` / `test_generate_dashboard.py` — OK
- [x] `markdownlint-cli2` — 0 errors
- [x] `generate_plugins.py` — no manifest drift

https://claude.ai/code/session_019DhHEZEiMAPidLpCV1nbPL

---
_Generated by [Claude Code](https://claude.ai/code/session_019DhHEZEiMAPidLpCV1nbPL)_