### PR TITLE
kb-management v3.4.4: dated Family-2 filenames + layer-agnostic template + ask-before-index-regen

### DIFF
--- a/plugins/kb/skills/kb-management/SKILL.md
+++ b/plugins/kb/skills/kb-management/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-management
 description: Lean, layered knowledge management driven by the `/kb` command. Captures material into a personal KB, routes to workstreams, applies a five-question evaluation gate, tracks decisions and ideas as first-class objects, manages tasks, generates versioned HTML artifacts, and promotes content across layers (personal, team, org-unit, marketplace). Triggered by `/kb` and knowledge-related phrases.
-version: 3.4.3
+version: 3.4.4
 triggers:
   - "/kb"
   - "knowledge base"
@@ -259,6 +259,7 @@ These files are loaded **only when the specific behavior is invoked**. The skill
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-04-23 | HTML artifact contract sharpened: (a) default filename pattern for Family-2 artifacts is now `YYYY-MM-DD-<slug>-v<major>.<minor>.html` across every layer; (b) styling is explicitly layer-agnostic \u2014 the configured `styling.reference-file` is THE template for all Family-2 artifacts in that layer; (c) after any Family-2 create/update the skill MUST offer root-`index.html` regeneration and proceed only on confirmation (automation levels 2/3 run silently) | Real-world friction during ISO 42001 presentation generation |
 | 2026-04-22 | Added topics to the dashboard command-center contract and bumped the declared skill version to 3.4.3 so first-class accreting knowledge is visible in live overviews | Fixes #22 |
 | 2026-04-22 | Added `_kb-references/strategy-digests/` to the personal-KB directory contract + REFERENCE.md workspace layout + `kb-setup` Step 3 scaffold — it was already used in practice (digest findings + `.last-digest` watermark read by the upstream-drift triage signal) but wasn't declared | Fixes #19 |
 | 2026-04-22 | Bumped declared skill version to 3.4.2 so the phantom-overview behavior fix ships under the current framework patch release | Version alignment |

--- a/plugins/kb/skills/kb-management/references/html-artifacts.md
+++ b/plugins/kb/skills/kb-management/references/html-artifacts.md
@@ -89,7 +89,8 @@ Every generated artifact:
 3. **Version watermark** on the intro slide / top of report — subtle, format: `v{version} · {date}`.
 4. **Changelog appendix** — the final slide (presentation) or section (report) lists versions.
 5. **Accessible** — semantic HTML, WCAG AA contrast, keyboard nav, alt text on images.
-6. **Versioned filenames** — `<slug>-v<major>.<minor>.html`. Regeneration writes a new file; does NOT overwrite old.
+6. **Versioned, dated filenames** — default pattern `YYYY-MM-DD-<slug>-v<major>.<minor>.html` for any topic-bound artifact (presentations, reports, pitches). Regeneration writes a new file; does NOT overwrite old. Dateless filenames are permitted only for always-current Family-1 overviews (`index.html`, `dashboard.html`). The rule is **layer-agnostic** — same filename convention for personal, team, and org-unit KBs.
+7. **Layer-agnostic styling** — the configured reference template in `.kb-config/artifacts.yaml` (`styling.reference-file`) is THE template for every Family-2 artifact in that layer. Never hand-roll a fresh palette or layout per run. If the user works in a workspace with multiple KB layers, each layer reuses its own configured template — but within one layer, every artifact looks like it comes from one brand.
 
 ## Styling sources
 
@@ -175,12 +176,14 @@ index:
   category-order: recency          # recency | fixed
 ```
 
-**Auto-regeneration**: The root `index.html` MUST be regenerated after every operation that creates or modifies an HTML artifact:
+**Auto-regeneration with confirmation**: After every operation that creates or modifies an HTML artifact, the skill MUST **offer** to regenerate the affected layer's root `index.html` — and proceed only on user confirmation (unless automation level is `2` or `3` per `.kb-config/automation.yaml`, in which case it runs silently). Regeneration targets the repo that received the new artifact, not every layer in the workspace.
+
+Triggers that prompt the offer:
 
 - `/kb present`, `/kb report`, `/kb end-day`, `/kb end-week`
 - Any Family 1 overview regeneration
-- Any `/kb promote` that includes HTML files
-- Manual trigger: `/kb status --refresh-overviews` (repair/rebuild path; not required for freshness)
+- Any `/kb promote` that copies HTML files across layers (offer for both source and destination layer)
+- Manual trigger: `/kb status --refresh-overviews` (repair/rebuild path; runs without prompting since it was explicitly invoked)
 
 **Regeneration command**:
 
@@ -245,6 +248,7 @@ Every `/kb present` MUST use this file (as customized by Q13) rather than regene
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-04-23 | Family-2 filename default is now `YYYY-MM-DD-<slug>-v<major>.<minor>.html` across every KB layer; styling contract is explicitly layer-agnostic (configured reference template is THE template per layer); root-`index.html` regeneration is now an explicit offer-then-confirm step after every Family-2 create/update (automation levels 2/3 still run silently) | ISO 42001 presentation generation friction |
 | 2026-04-22 | Root `index.html` source-of-truth row now lists findings/topics/ideas/decisions markdown alongside HTML artifacts, matching the shipped generator behavior | Fixes #21 |
 | 2026-04-22 | Added topics to the dashboard Family-1 contract and source-of-truth table so living positions are visible alongside findings, ideas, and decisions | Fixes #22 |
 | 2026-04-22 | Dropped the three phantom Family-1 overviews (`inventory.html`, `open-decisions.html`, `open-tasks.html`) that had no shipped generator; their signals already live in `dashboard.html` panels | Fixes #18 |


### PR DESCRIPTION
## What

Three tightening rules for the HTML artifact contract, driven by real-world friction generating a team-KB presentation:

1. **Dated filenames for Family-2 artifacts.** Default pattern is now `YYYY-MM-DD-<slug>-v<major>.<minor>.html` across every layer (personal, team, org-unit). Dateless filenames are reserved for always-current Family-1 overviews (`index.html`, `dashboard.html`). Makes chronological scanning of a reports directory trivial and matches how humans name meeting artifacts.

2. **Layer-agnostic styling, explicitly.** The configured `styling.reference-file` in `.kb-config/artifacts.yaml` is **THE** template for every Family-2 artifact in that layer. Never hand-roll a fresh palette per run. Within one layer, every artifact looks like it comes from one brand.

3. **Offer-then-confirm index regeneration.** After creating or modifying any HTML artifact, the skill MUST offer to regenerate the affected repo's root `index.html` and proceed only on user confirmation. Automation levels 2/3 still run silently. Triggers enumerated.

## Why

When I generated a 2-slide decision brief for a team KB today, none of these were wrong — but the rules weren't explicit enough to prevent a sloppy first pass (undated filename, unclear which layer's template to use, no prompt to refresh the index). Codifying them closes the gap.

## Version

`kb-management` bumped to **v3.4.4** (patch — docs-only, no behavior changes beyond the contract tightening).