### PR TITLE
fix(ci): add trailing newline to docs/operating-model.md (MD047)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 ## [Unreleased]
 
 - Post-5.3.0 follow-ups only.
+- CI fix: appended the missing trailing newline to `docs/operating-model.md` so `markdownlint` (MD047) passes again. No semantic change.
 
 ## [5.3.0] — 2026-04-26
 

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -164,3 +164,4 @@ Those surfaces may still feed findings, briefs, specs, releases, or incidents th
 | Date | What changed | Source |
 |------|-------------|--------|
 | 2026-04-26 | Initial operating-model analysis and artifact-gap definition for company-wide software engineering work; introduced the delivery/operations gap narrative for briefs, specs, releases, and incidents | Gap analysis for software-engineering daily work |
+| 2026-04-27 | Appended missing trailing newline to satisfy `markdownlint` MD047; no semantic change | CI fix |


### PR DESCRIPTION
## Summary

The `markdown-lint` job in the `Validate` workflow was failing with:

```
docs/operating-model.md:166:264 error MD047/single-trailing-newline Files should end with a single newline character
```

The file landed in commits `f92c567` and `ae333aa` without a trailing newline, which broke CI on `main` after those commits. This PR appends the missing newline and records the fix in both the per-file changelog and the root `CHANGELOG.md` `[Unreleased]` section, per `AGENTS.md` rule 3.

No semantic change to the operating-model document.

## Local validation

- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` → 0 errors (was 1 before the fix)
- [x] `python3 scripts/check_consistency.py` → OK
- [x] `python3 scripts/check_plugin_structure.py` → OK
- [x] `python3 scripts/generate_plugins.py` → no drift
- [x] `python3 scripts/check_html_artifacts.py` → OK
- [x] `python3 scripts/test_html_templates.py` → OK
- [x] `python3 scripts/test_generate_index.py` → OK
- [x] `python3 scripts/test_generate_dashboard.py` → OK
- [x] `python3 scripts/test_kb_roadmap.py` → OK
- [x] `python3 scripts/test_kb_migrations.py` → OK
- [ ] `python3 scripts/test_acceptance_fixture.py` → blocked locally by sandbox commit-signing (same known limitation called out in PR #74); will run cleanly in GitHub Actions
- [ ] `lychee` not available locally; CI will run it

https://claude.ai/code/session_014kXmkGXi5CqvVe39B4ifkN

---
_Generated by [Claude Code](https://claude.ai/code/session_014kXmkGXi5CqvVe39B4ifkN)_