### PR TITLE
fix: close onboarding-flow consistency gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ## [Unreleased]
 
+### Fixed
+
+- **Onboarding flow consistency review** — closed five long-standing gaps that prevented the documented "answer the wizard, get the promised artifacts" contract from working end-to-end:
+  1. `docs/first-run-acceptance.md` was a release behind. Phase 2 is now numbered Q9/Q10/Q11 (was Q8/Q9/Q10), and the missing Q8 (operating context / adoption stage, added in v5.4.0) is back in the baseline answer set with `human-only / capture discipline today; agent-assisted triage in 6 months` mapping to Stage 1. Phase 3 expected output now requires the adoption-stage label, the Stage↔automation-level consistency check, and the graduation-criteria block, so the team-lead acceptance baseline actually exercises the soft-transition flow it advertises.
+  2. `plugins/kb/skills/kb-setup/SKILL.md` placeholder mapping was incomplete and used stale Q-numbers in two rows. The mapping now documents the global Q-numbering convention and lists every placeholder the templates emit (`{{THEMES}}`, `{{WORKSTREAMS}}`, `{{TEAM_NAME}}`, `{{ORG_UNIT_NAME}}`, `{{REPO_INDEX}}`, `{{ALIAS_INDEX}}`, `{{KEYWORD_LOOKUP}}`, `{{VMG_VISION}}`, `{{VMG_MISSION}}`, `{{VMG_GOALS}}`, `{{AUTOMATION_LEVEL}}`), so the post-write placeholder scan no longer hits undocumented tokens. Skill version bumped to 5.5.1.
+  3. `plugins/kb/skills/kb-setup/templates/foundation-me.md` and `plugins/kb/skills/kb-setup/templates/automation.yaml` now carry the `{{ADOPTION_STAGE}}` slot the SKILL.md placeholder mapping promised since v5.4.0. The chosen stage is now durable in the scaffold instead of implicit.
+  4. `plugins/kb/skills/kb-setup/templates/automation.yaml` no longer ships `level: 1` together with active schedules. The schedules block is commented out by default (the wizard uncomments and fills it only at level ≥ 2), and the file gained an `adoption-stage` field plus the level-mapping comment block, matching the contract in `references/automation-levels.md`. The `level` field is now a `{{AUTOMATION_LEVEL}}` placeholder so the wizard can write the chosen level cleanly.
+  5. `plugins/kb/skills/kb-management/references/html-artifacts.md` and `plugins/kb/skills/kb-setup/templates/presentation-template.html` no longer point at "kb-setup Q13" for the presentation-template copy step — they now reference the phase-3 HTML-styling step, which survives any future renumbering.
+- **`docs/examples/first-hour.md` walkthrough refreshed (v5.0.0 → v5.5.1)** — replaced the legacy "Block | Suggested first-run answer" table that contradicted the v5.2.0 "Never ask the user to enumerate layers, features, contributor-mode flags, or scopes in phase 1" rule with the goal-oriented four-phase interview, including the Q8 operating-context answer and the phase-3 confirmation block. Success checks now also assert that the chosen adoption stage is durable in `automation.yaml` and `foundation/me.md`.
+
 - Post-5.5.1 follow-ups only.
 
 ## [5.5.1] — 2026-04-30

--- a/docs/examples/first-hour.md
+++ b/docs/examples/first-hour.md
@@ -1,6 +1,6 @@
 # First Hour — Zero to First Useful Layer Graph
 
-> **Version:** 5.0.0 | **Last updated:** 2026-04-25
+> **Version:** 5.5.1 | **Last updated:** 2026-05-05
 
 This walkthrough covers the minimum path from nothing installed to the first useful `/kb` responses in a freshly initialized workspace. Target audience: a developer who wants to prove the adoption path end-to-end in under an hour.
 
@@ -27,28 +27,38 @@ Run:
 /kb setup
 ```
 
-Use this first-run answer set:
+The wizard runs the four-phase, goal-oriented interview. You never enumerate layers, features, or contributor-mode flags yourself — the wizard derives them from your prose and shows the proposal back in phase 3.
 
-| Block | Suggested first-run answer |
-|------|-----------------------------|
-| Name | `alice` |
-| Role and themes | `engineer on distributed systems — caching, reliability, observability` |
-| Workspace root | current directory |
-| Discovery pass | accept the empty baseline |
-| Layer 1 | `alice-personal`, `scope: personal`, `role: contributor`, `parent: team-observability`, features `inputs, findings, topics, ideas, decisions, tasks, notes, workstreams, foundation, reports` |
-| Layer 2 | `team-observability`, `scope: team`, `role: contributor`, `parent: null`, features `findings, topics, decisions, tasks, notes, foundation, reports`, contributor-mode `notes: shared` |
-| Anchor layer | `alice-personal` |
-| Workstreams | `platform-signals` |
-| IDE targets | current harness only |
-| Connections | skip |
-| Draft features | skip |
-| Automation | `1` (manual only) |
-| HTML styling | `builtin` |
+**Phase 1 — context and goals (open prose, Q1–Q8):**
+
+| Question | Suggested first-run answer |
+|----------|----------------------------|
+| Q1 — Who you are | `alice — engineer on distributed systems; caching, reliability, observability` |
+| Q2 — What you're trying to track or decide | `incidents and slow queries that hint at deeper reliability issues` |
+| Q3 — Why now | `too many parallel investigations; my lead keeps asking for status` |
+| Q4 — Who else needs to see what | `me and one team — observability` |
+| Q5 — Where information feeds in | `our product repo, GitHub issues, weekly observability sync` |
+| Q6 — What you want out | `morning briefing and a Friday status I can share with my lead` |
+| Q7 — How autonomous | `confirm everything before anything is written` |
+| Q8 — Operating context today, target in 6 months | `human-only / capture discipline today; agent-assisted triage in 6 months` |
+
+**Phase 2 — workspace and harness facts (Q9–Q11):**
+
+| Question | Suggested first-run answer |
+|----------|----------------------------|
+| Q9 — Workspace root | current directory |
+| Q10 — IDE targets | current harness only |
+| Q11 — Discovery pass | accept the empty baseline |
+
+**Phase 3 — confirm the wizard's derived plan (Q12–Q15):** the wizard shows a single block with the proposed layer graph (`alice-personal` + `team-observability`), the adoption-stage label (`Stage 1 — capture discipline`), the connections derived from Q5, the dashboard panels matching Q6, automation level `1` (manual only — consistent with Stage 1), the graduation criteria for moving to Stage 2, and HTML styling `builtin`. Accept as proposed.
+
+**Phase 4 (Q16):** one yes.
 
 Check for success:
 
-- `.kb-config/layers.yaml` exists in `alice-personal/`,
-- the file names both layers and sets `workspace.anchor-layer: alice-personal`,
+- `.kb-config/layers.yaml` exists in `alice-personal/` and names both layers with `workspace.anchor-layer: alice-personal`,
+- `.kb-config/automation.yaml` carries the chosen `adoption-stage` and a `level` consistent with Stage 1,
+- `_kb-references/foundation/me.md` records the same adoption stage,
 - year-based archive directories exist,
 - `index.html` and `dashboard.html` exist in both layers,
 - no unresolved placeholders remain outside deliberate presentation templates.
@@ -116,6 +126,7 @@ If the command targets a `role: consumer` layer, it must refuse clearly.
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-05 | v5.5.1: replaced the legacy block-and-answer table that asked the user to enumerate layers, features, and contributor-mode flags with the goal-oriented four-phase interview (Q1–Q8 prose, Q9–Q11 admin, Q12–Q15 confirm-the-derived-plan, Q16 final yes), matching `kb-setup/SKILL.md` since v5.4.0. Success checks now also assert that the chosen adoption stage is durable in `automation.yaml` and `foundation/me.md` | Onboarding consistency review |
 | 2026-04-25 | Aligned the walkthrough with the acceptance baseline: Stage wording became Phase wording, the sample layer answers now include the parent graph fields, and automation level 1 is called out as manual-only | Deep spec-audit follow-up |
 | 2026-04-25 | Reworked the walkthrough for 5.0.0: setup now proves a two-layer graph, year-based archives, notes, and the first cross-layer promote path | v5.0.0 flexible layer model |
 | 2026-04-24 | Updated the Codex walkthrough to the installed `.agents/skills/` flow instead of the older bootstrap-only wording | Harness docs correction |

--- a/docs/first-run-acceptance.md
+++ b/docs/first-run-acceptance.md
@@ -1,6 +1,6 @@
 # First-Run Acceptance Path
 
-> **Version:** 5.5.0 | **Last updated:** 2026-04-30
+> **Version:** 5.5.1 | **Last updated:** 2026-05-05
 
 This document defines the canonical first-run acceptance path for `agentic-kb`.
 
@@ -217,14 +217,15 @@ The setup wizard runs the four-phase, goal-oriented interview defined in `plugin
 | Q5 — Where information feeds in | `our product repo, GitHub issues, and the weekly observability sync` |
 | Q6 — What you want out | `a morning briefing and a Friday status I can share with my lead` |
 | Q7 — How autonomous | `I want to confirm everything before anything is written` |
+| Q8 — Operating context today, and target in 6 months | `human-only / capture discipline first today; agent-assisted triage in 6 months` (maps to **adoption stage 1** today, stage 2 as the next graduation target per `plugins/kb/skills/kb-setup/references/adoption-stages.md`) |
 
 ### Phase 2 — Workspace and harness facts
 
 | Question | Baseline answer |
 |----------|-----------------|
-| Q8 — Workspace root | current directory / `<workspace>/demo-agentic-kb` |
-| Q9 — IDE targets | current harness only |
-| Q10 — Discovery pass | accept the reported empty baseline |
+| Q9 — Workspace root | current directory / `<workspace>/demo-agentic-kb` |
+| Q10 — IDE targets | current harness only |
+| Q11 — Discovery pass | accept the reported empty baseline (no repo-as-OS structure detected) |
 
 ### Phase 3 — Proposed plan (the wizard shows, you confirm)
 
@@ -232,13 +233,15 @@ The wizard must derive and propose:
 
 - two layers — `alice-personal` (scope `personal`, role `contributor`, parent `team-observability`, features `inputs, findings, topics, ideas, decisions, tasks, notes, workstreams, foundation, reports`) and `team-observability` (scope `team`, role `contributor`, parent `null`, features `findings, topics, decisions, tasks, notes, foundation, reports`, contributor-mode `notes: shared`),
 - anchor layer `alice-personal`,
+- **adoption-stage label**: `Stage 1 — capture discipline (human-only baseline)`, derived from Q8 + Q7 per `references/adoption-stages.md`. The proposal must show the stage explicitly so the user can see the wizard is suggesting a capture-only scaffold rather than an agent-assisted or bounded-autonomous one,
 - workstream `platform-signals` extracted from Q2,
 - connections containing the product repo and GitHub issues from Q5,
 - dashboard and report panels matching Q6 (morning briefing + weekly status),
-- automation level `1` (manual only) — mapped from Q7's "confirm everything" answer; Q6's regular outputs are run by the user, not on a schedule, at this baseline,
+- automation level `1` (manual only) — mapped from Q7's "confirm everything" answer and consistent with the Stage-1 label (a Stage-1 team must not be configured at automation level 2 or 3). Q6's regular outputs are run by the user, not on a schedule, at this baseline,
+- **graduation criteria for Stage 1 → Stage 2** surfaced as informational defaults (e.g. "≥ 4 weeks of clean `.kb-log/`", "≥ 1 cross-layer promote completed by hand", "`foundation/vmg.md` confirmed by ≥ 1 stakeholder"); the user can accept, edit, or skip this block — it does not block scaffold,
 - HTML styling `builtin`.
 
-Acceptance for phase 3: the user accepts the proposal as-is.
+Acceptance for phase 3: the user accepts the proposal as-is, including the adoption-stage label and the (optional) graduation-criteria block.
 
 ### Phase 4 — Final confirmation
 
@@ -248,6 +251,8 @@ Expected result:
 
 - the user never had to enumerate features, scopes, or contributor-mode flags themselves,
 - every phase 1 answer maps to at least one concrete artifact or config effect in the proposal,
+- the proposed adoption stage matches the Q8 answer (Stage-1 today does not produce a Stage-3 scaffold and vice versa),
+- the chosen adoption stage is durable in the scaffold — it appears in `automation.yaml` and in `_kb-references/foundation/me.md`, not only in conversation,
 - the skill does not ask hidden prerequisite questions later,
 - the user can complete setup without already knowing the internal file model.
 
@@ -492,6 +497,7 @@ Create or reopen an issue if any of these occur:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-05 | v5.5.1: closed the v5.4.0 numbering drift. Phase 1 now baselines Q1–Q8 (Q8 = operating context / adoption stage, which had been silently dropped from this doc since v5.4.0). Phase 2 questions are renumbered Q9/Q10/Q11 to match `kb-setup/SKILL.md`. Phase 3 expected output now requires the adoption-stage label, explicit Stage↔automation-level consistency, and the graduation-criteria block, so the acceptance baseline actually proves the soft-transition flow it advertises. Added an explicit acceptance bullet that the chosen stage must be durable in `automation.yaml` and `foundation/me.md` | Onboarding consistency review |
 | 2026-04-30 | v5.5.0: added the optional product-management proof path so first-run acceptance covers setup-derived roadmap/journey ownership, source/output placement, and read-only dry-run validation when role/goals imply those artifacts | Product-management surface integration |
 | 2026-04-25 | v5.2.0: replaced the flat 13-question baseline with the four-phase, goal-oriented interview (Phase 1 context/goals, Phase 2 workspace facts, Phase 3 derived plan to confirm, Phase 4 single yes) so the canonical proof matches the new kb-setup behavior. Layer features and contributor-mode flags are now derived in Phase 3 from the user's own answers, not enumerated by the user. Q7 baseline answer pinned to "confirm everything" so the derived automation level stays at 1 (manual only) per the existing baseline | v5.2.0 setup rework |
 | 2026-04-25 | Clarified the baseline automation answer so level 1 is explicitly the manual-only setup path | Deep spec-audit follow-up |

--- a/plugins/kb/skills/kb-management/references/html-artifacts.md
+++ b/plugins/kb/skills/kb-management/references/html-artifacts.md
@@ -247,7 +247,7 @@ The generator fills placeholders from `.kb-config/artifacts.yaml` + topic conten
 
 ### Presentation-grade template
 
-For `/kb present` (and any slide-style report), the richer **`kb-setup/templates/presentation-template.html`** is the canonical starting point. kb-setup Q13 copies it into the adopter's KB under `_kb-references/templates/presentation-template.html` (or `<brand>-presentation.html` when a brand is supplied). It ships with:
+For `/kb present` (and any slide-style report), the richer **`kb-setup/templates/presentation-template.html`** is the canonical starting point. The kb-setup HTML-styling step in phase 3 copies it into the adopter's KB under `_kb-references/templates/presentation-template.html` (or `<brand>-presentation.html` when a brand is supplied). It ships with:
 
 - Dark + light theme token blocks (all customization points marked `CUSTOMIZE:`).
 - Slide types: `.cover`, `.section-title`, `.content`, `.full-image`, `.closing`.
@@ -257,12 +257,13 @@ For `/kb present` (and any slide-style report), the richer **`kb-setup/templates
 - Nav bar with keyboard shortcuts (←/→, Home, End, PgUp/PgDn, Space), progress bar, print CSS.
 - Built-in appendix/changelog slide.
 
-Every `/kb present` MUST use this file (as customized by Q13) rather than regenerating a fresh layout.
+Every `/kb present` MUST use this file (as customized by the phase-3 HTML-styling step) rather than regenerating a fresh layout.
 
 ## Changelog
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-05 | Replaced two stale "kb-setup Q13" references for the presentation-template copy step with phase-relative wording so the doc no longer points at a question number that the v5.4.0 renumbering invalidated. Behavioral contract unchanged | Onboarding consistency review |
 | 2026-04-25 | Added an explicit external-read preflight contract plus a mandatory post-generation QA sweep so artifact generation has reviewable fetch boundaries and a defined completion gate | Generic learnings extracted from roadmap/presentation feature work |
 | 2026-04-23 | Family-2 filename default is now `YYYY-MM-DD-<slug>-v<major>.<minor>.html` across every KB layer; styling contract is explicitly layer-agnostic (configured reference template is THE template per layer); root-`index.html` regeneration is now an explicit offer-then-confirm step after every Family-2 create/update (automation levels 2/3 still run silently) | ISO 42001 presentation generation friction |
 | 2026-04-22 | Root `index.html` source-of-truth row now lists findings/topics/ideas/decisions markdown alongside HTML artifacts, matching the shipped generator behavior | Fixes #21 |

--- a/plugins/kb/skills/kb-setup/SKILL.md
+++ b/plugins/kb/skills/kb-setup/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-setup
 description: Interactive onboarding wizard that scaffolds an agentic-kb workspace around a flexible layer graph. Asks the user about their context, goals, audience, sources, and desired outputs first, derives a proposed layer graph and feature set including product-management roadmap/journey placement when relevant, then creates or onboards layer repos, writes the anchor-layer config, configures documented harness workflows, and generates the required templates, indexes, and HTML style references.
-version: 5.5.0
+version: 5.5.1
 triggers:
   - "/kb setup"
   - "setup kb"
@@ -216,16 +216,24 @@ Running `/kb setup` again:
 
 ## Placeholder mapping
 
+Question references in this table use the global numbering: phase 1 covers Q1–Q8, phase 2 covers Q9–Q11, phase 3 covers Q12–Q15 (proposal blocks the user adjusts or accepts), phase 4 covers Q16 (final yes).
+
 The layer-graph scaffold uses these placeholders directly:
 
 | Placeholder | Source |
 |-------------|--------|
 | `{{USER_NAME}}` | Q1 |
 | `{{ROLE}}` | Q1 (role sentence extracted from the same answer) |
-| `{{KB_NAME}}` | anchor-layer name (derived in Q12) |
+| `{{THEMES}}` | extracted from Q1/Q2 (3–5 keywords); rendered as a bullet list into `foundation/me.md` |
+| `{{KB_NAME}}` | anchor-layer name (derived and confirmed in phase 3 question 1, i.e. Q12) |
 | `{{WORKSPACE_ROOT}}` | Q9 |
-| `{{WORKSTREAM_1_NAME}}`, `{{WORKSTREAM_1_THEMES}}` | extracted from Q2 (themes) and confirmed in Q12 |
+| `{{WORKSTREAM_1_NAME}}`, `{{WORKSTREAM_1_THEMES}}` | extracted from Q2 (themes) and confirmed in phase 3 question 1 (Q12) |
+| `{{WORKSTREAMS}}` | rendered list of all confirmed workstreams (`{{WORKSTREAM_1_*}}`, `{{WORKSTREAM_2_*}}`, …) for `personal-kb-AGENTS.md` |
 | `{{ADOPTION_STAGE}}` | derived from Q8 (today bucket); used in `automation.yaml` and the scaffolded `foundation/me.md` so the chosen stage is durable, not implicit |
+| `{{AUTOMATION_LEVEL}}` | derived from Q7 + Q8 (1, 2, or 3 per `references/automation-levels.md`); written into `automation.yaml` |
+| `{{TEAM_NAME}}`, `{{ORG_UNIT_NAME}}` | layer name from phase 3 question 1 (Q12) when the proposal includes a shared contributor or synthesis layer; used by the `team-kb-*` and `org-kb-*` templates |
+| `{{REPO_INDEX}}`, `{{ALIAS_INDEX}}`, `{{KEYWORD_LOOKUP}}` | rendered from the discovered + confirmed repo set (Q11 + phase 3 question 1, Q12); used by `workspace-AGENTS.md` |
+| `{{VMG_VISION}}`, `{{VMG_MISSION}}`, `{{VMG_GOALS}}` | populated by the VMG sourcing step (URL fetch, file read, or direct text per `references/setup-flow.md`); placeholders survive only if the user opts to fill VMG later, in which case a backlog item is created |
 | `{{DATE}}` | today |
 | `{{VERSION}}` | `1.0` on first scaffold |
 
@@ -253,6 +261,7 @@ After writing the scaffold, scan the workspace for any remaining `{{...}}` seque
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-05 | v5.5.1: closed the placeholder-mapping gap that had been silently broken since the goal-oriented + adoption-stage extensions. Documented the global Q-numbering convention, listed the previously-undocumented placeholders the templates emit (`{{THEMES}}`, `{{WORKSTREAMS}}`, `{{TEAM_NAME}}`, `{{ORG_UNIT_NAME}}`, `{{REPO_INDEX}}`, `{{ALIAS_INDEX}}`, `{{KEYWORD_LOOKUP}}`, `{{VMG_VISION}}`, `{{VMG_MISSION}}`, `{{VMG_GOALS}}`, `{{AUTOMATION_LEVEL}}`), and replaced the stale "Q12" wording with phase-3-question-1 wording so the table no longer reads as off-by-one | Onboarding consistency review |
 | 2026-04-30 | Version aligned to 5.5.0 after making roadmap and journey work a setup-proposed product-management surface. Setup now derives roadmap/journey features from role/goals/outputs, asks which layer owns them, and writes matching config only after confirmation | Product-management surface integration |
 | 2026-04-29 | Skill version aligned to 5.4.2 after the draft-skill discoverability fix. The packaged `kb.prompt.md` template now routes `/kb roadmap` and `/kb journeys` to the matching draft skills with a config-block check; this skill's setup-flow contract is unchanged | v5.4.2 draft-skill discoverability fix |
 | 2026-04-27 | Skill version aligned to 5.4.1 after the documentation-gap follow-up. Clarified the repo-as-OS bridge field name to `connections.product-repos[]` and linked the setup-flow VMG sourcing/update guidance | 5.4.1 patch release |

--- a/plugins/kb/skills/kb-setup/templates/automation.yaml
+++ b/plugins/kb/skills/kb-setup/templates/automation.yaml
@@ -1,13 +1,30 @@
 # Automation configuration for the anchor layer.
-# Levels: 1 (manual), 2 (semi-auto), 3 (full-auto).
+# Levels (see plugins/kb/skills/kb-setup/references/automation-levels.md):
+#   1 — Manual only. `schedules:` MUST stay omitted or inactive.
+#       `auto-promote.enabled: false`.
+#   2 — Scheduled rituals and digests. `auto-promote.enabled: false`.
+#   3 — Scheduled rituals plus guarded auto-promote.
+#       `auto-promote.enabled: true` only with confidence threshold +
+#       excluded workstreams + an explicit user opt-in.
 
-level: 1
+level: {{AUTOMATION_LEVEL}}
 
-schedules:
-  start-day: "daily 08:00"
-  end-day: "daily 18:00"
-  start-week: "monday 08:00"
-  end-week: "friday 15:00"
+# Adoption stage chosen at setup. Recorded here so the configuration knob
+# (`level`) cannot drift away from the team's posture toward the agent.
+# A Stage-1 team must not be configured at level 2 or 3; a Stage-3 team
+# should not stay at level 1. See
+# plugins/kb/skills/kb-setup/references/adoption-stages.md for the full
+# stage ↔ level mapping.
+adoption-stage: {{ADOPTION_STAGE}}
+
+# Schedules are written by /kb setup ONLY when level >= 2. At level 1 the
+# block stays commented out so a manual-only adopter never gets surprise
+# scheduled runs. The wizard uncomments and fills the entries it needs.
+# schedules:
+#   start-day: "daily 08:00"
+#   end-day: "daily 18:00"
+#   start-week: "monday 08:00"
+#   end-week: "friday 15:00"
 
 auto-promote:
   enabled: false

--- a/plugins/kb/skills/kb-setup/templates/foundation-me.md
+++ b/plugins/kb/skills/kb-setup/templates/foundation-me.md
@@ -11,6 +11,15 @@
 
 {{THEMES}}
 
+## Adoption stage
+
+> Stage chosen at setup so future agents can see the team's posture toward
+> automation without re-asking. See
+> `plugins/kb/skills/kb-setup/references/adoption-stages.md` for the
+> graduation criteria between stages.
+
+- **Stage**: {{ADOPTION_STAGE}}
+
 ## Working style
 
 <!-- How do you work? What do you care about? What bores or drains you?

--- a/plugins/kb/skills/kb-setup/templates/presentation-template.html
+++ b/plugins/kb/skills/kb-setup/templates/presentation-template.html
@@ -10,8 +10,9 @@
 /* ═══════════════════════════════════════════════════════════════════════
    AGENTIC-KB HTML PRESENTATION TEMPLATE (vendor-neutral)
    ──────────────────────────────────────────────────────
-   Ships with kb-setup. On `/kb setup` Q13 the wizard copies this file
-   into `_kb-references/templates/<brand>-presentation.html` and rewrites
+   Ships with kb-setup. On the phase-3 HTML-styling step of `/kb setup`
+   the wizard copies this file into
+   `_kb-references/templates/<brand>-presentation.html` and rewrites
    the token blocks below to match the adopter's corporate design.
 
    CUSTOMIZATION POINTS (search for "CUSTOMIZE:"):
@@ -429,7 +430,8 @@ tbody tr:hover { background: var(--bg-card-hover); }
 <!-- ═══ HEADER (logo + theme toggle) ════════════════════════════════ -->
 <div class="header-bar">
   <!-- CUSTOMIZE: replace the <svg> below with the adopter's signet SVG.
-       The wizard copies the brand signet from Q13 setup input into here. -->
+       The wizard copies the brand signet from the phase-3 HTML-styling
+       setup input into here. -->
   <a class="brand-logo" href="#" aria-label="{{BRAND_NAME}}">
     <svg viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
       <rect x="2" y="2" width="28" height="28" rx="6" fill="var(--brand)"/>


### PR DESCRIPTION
## Summary

Deep review of the four-phase `/kb setup` interview against `kb-setup/SKILL.md`, `first-run-acceptance.md`, the scaffold templates, and the `html-artifacts.md` contract surfaced five concrete consistency gaps that broke the "answer the wizard, get the promised artifacts" contract end-to-end. None of them changed semantics — they were drift from the v5.2.0 (goal-oriented flow) and v5.4.0 (adoption-stage Q8) extensions that never made it into every doc/template that referenced the renumbering.

### What was actually broken

1. **`docs/first-run-acceptance.md` was a release behind.** Phase 2 was numbered Q8/Q9/Q10 instead of Q9/Q10/Q11. Q8 (operating context / adoption stage, added in v5.4.0) was missing from the baseline answer set entirely. Phase 3 expected output never required the adoption-stage label or graduation-criteria block, despite SKILL.md mandating both — so the team-lead acceptance baseline never actually exercised the soft-transition flow it advertised.
2. **`plugins/kb/skills/kb-setup/SKILL.md` placeholder mapping was incomplete and used stale Q-numbers.** Templates emit `{{THEMES}}`, `{{VMG_VISION/MISSION/GOALS}}`, `{{WORKSTREAMS}}`, `{{REPO_INDEX}}`, `{{ALIAS_INDEX}}`, `{{KEYWORD_LOOKUP}}`, `{{TEAM_NAME}}`, `{{ORG_UNIT_NAME}}` — none of which appeared in the placeholder mapping. The post-write placeholder scan would have stopped on these, or the wizard ran undocumented inference logic.
3. **`{{ADOPTION_STAGE}}` was promised in `automation.yaml` and `foundation/me.md` but missing from both templates.** SKILL.md said "the chosen stage is durable, not implicit" — but the templates had no slot for it.
4. **`automation.yaml` shipped `level: 1` with active `schedules:`** — directly contradicting `automation-levels.md` ("Level 1 ... `schedules:` may be omitted or left inactive").
5. **`html-artifacts.md` and `presentation-template.html` referenced a stale "kb-setup Q13"** for the presentation-template copy step. After v5.4.0 added Q8, the HTML-styling step lives at phase 3 / Q15 globally — the old Q13 reference was off by two.

### What this PR changes

- Repaired Q-numbering and added the missing Q8 + adoption-stage / graduation-criteria expectations to `first-run-acceptance.md` (v5.5.1).
- Closed the placeholder-mapping gap in `kb-setup/SKILL.md` and replaced stale Q12 wording with phase-relative wording (skill v5.5.1).
- Added `{{ADOPTION_STAGE}}` slot to `foundation-me.md`; added `adoption-stage` field + `{{AUTOMATION_LEVEL}}` placeholder to `automation.yaml`; commented out the schedules block at level 1 default to honor the level-mapping contract.
- Replaced two stale "Q13" references in `html-artifacts.md` and `presentation-template.html` with phase-relative wording.
- Refreshed `docs/examples/first-hour.md` from v5.0.0 to v5.5.1 — replaced the legacy block-and-answer table (which asked the user to enumerate layers/features, contradicting the v5.2.0 rule) with the goal-oriented four-phase interview.
- Per-file changelog rows + an `[Unreleased]` block in the root `CHANGELOG.md`.

No behavioral spec change. Root `VERSION` stays at 5.5.1; per-file versions on the touched skill/doc files moved to 5.5.1.

## Test plan

- [x] `python3 scripts/check_consistency.py` — green
- [x] `python3 scripts/check_plugin_structure.py` — green
- [x] `npx markdownlint-cli2 "docs/**/*.md" "*.md"` — green
- [x] `python3 scripts/generate_plugins.py` — manifest unchanged (no plugin-version drift)
- [ ] Lychee dead-link check (CI)

https://claude.ai/code/session_017EahQ9QzH6ynkq7ZfXVaSd

---
_Generated by [Claude Code](https://claude.ai/code/session_017EahQ9QzH6ynkq7ZfXVaSd)_