### PR TITLE
Role handbook + retro variant + workstream/day-in-the-life enrichment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-> **Version:** 0.9 | **Last updated:** 2026-05-10
+> **Version:** 0.10 | **Last updated:** 2026-05-14
 
 This file is read first by any AI agent (and any human) working in this repository. It defines the ground rules. Layer-specific documents in `docs/` extend these rules — they never override them.
 
@@ -89,6 +89,7 @@ Keep this stated once, crisply, and point to the owning contract instead of rest
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-14 | Bumped AGENTS version to 0.10 to track the daily-reality role-coverage extension landing under `[Unreleased]`: new `docs/role-handbook.md`, new retro note variant (template + `/kb note retro` verb + REFERENCE §4 Note-format extension), workstream template enriched with status/owner/cadence/linked-delivery and shipment/milestone tables, and three new day-in-the-life scenes (PM/EM/on-call SRE). AGENTS rules unchanged in semantics | Daily-reality gap audit across software-company roles |
 | 2026-05-10 | v6.0.0 release alignment — bumped AGENTS version to 0.9 to track the v5 adoption-arc closeout (canonical `/kb brief`, `/kb spec`, `/kb release`, `/kb incident` verbs; REFERENCE ↔ template format alignment for the four delivery/operations artifacts; removal of residual fixed-ladder L1/L2/L3/L4 vocabulary; year-nested archive and weekly-summary path corrections; five missing changelog sections added). AGENTS rules unchanged in semantics | v6.0.0 adoption + daily-usage gap audit |
 | 2026-04-30 | v5.5.1 release alignment — bumped AGENTS version to 0.8 to track the HTML landing-page value-prop correction. AGENTS rules unchanged in semantics | HTML value-prop correction |
 | 2026-04-30 | v5.5.0 release alignment — bumped AGENTS version to 0.7 to track the product-management roadmap/journey surface integration. AGENTS rules unchanged in semantics | Product-management surface integration |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,19 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ## [Unreleased]
 
-- Post-6.0.0 follow-ups only.
+### Added
+
+- **Role handbook** — `docs/role-handbook.md` is the new role-by-role companion to `docs/operating-model.md`. It maps PM, EM, staff/principal engineer, tech lead, engineer, designer, QA, SRE/on-call, security, and data/analytics each to their daily reality, primary operating-model loop, top `/kb` commands, primary artifacts read and written, and one realistic chain through the artifact graph. The operating model stays the analytical view; the handbook is the usable view. Referenced from `README.md` "Where to start" and from the top of `docs/operating-model.md`.
+- **Retro note variant** — `/kb note retro [topic]` opens a structured retrospective using a new `plugins/kb/skills/kb-management/templates/retro.md` template (sections: Context, What went well, What didn't, What we changed already, What we will change, Open questions, Linked artifacts). Retros live inside the existing `notes` feature under `_kb-notes/YYYY/` with `type: retro` and adds `cadence`, `facilitator`, `period` frontmatter — no new feature flag or directory. `docs/REFERENCE.md` §4 carries the file format; `command-reference.md` carries the verb and the false-convergence flag rule (a retro that closes without any tracked commitment surfaces a Gate-note warning instead of silently filing).
+- **Three additional day-in-the-life scenes** — `docs/examples/day-in-the-life.md` now shows compact PM (Priya), EM (Eun-ji), and on-call SRE (Marek) days alongside the existing principal-engineer (Alex) walkthrough, exercising `/kb brief`, `/kb decide`, `/kb note meeting`, `/kb note retro`, `/kb incident`, `/kb report roadmap-change`, and `/kb report status` end-to-end.
+- **Retro/retrospective/post-mortem trigger phrases** added to `kb-management/SKILL.md` so natural-language invocations route to the retro variant without requiring the literal `/kb` prefix.
+
+### Changed
+
+- **`workstream.md` template enriched** — added Owner, Status, Cadence, Last reviewed, Linked briefs/specs, a "Recent shipments" table, and an "Upcoming milestones" table. Workstreams are long-running primary org units and the previous 17-line template was too thin to support that role.
+- **Operating model v0.3.0** — named Gap F (no canonical shape for team reflection — closed by the retro variant) and Gap G (no user-facing role view — closed by the role handbook). Retros added to the §1 Learning-loop artifact list, the §6 artifact table, and the §7 modeling rule of thumb.
+- **Reference v6.1.0** — §4 Note format now declares the retro variant: `type` accepts `meeting | note | retro`, with the structured section set and the `cadence`/`facilitator`/`period` frontmatter documented inline.
+- **kb-management SKILL v6.1.0** — description mentions retros, template list now includes `retro.md`, and the Note flow row covers the three variants.
 
 ## [6.0.0] — 2026-05-10
 

--- a/README.md
+++ b/README.md
@@ -311,12 +311,13 @@ agentic-kb/
 
 1. [`docs/REFERENCE.md`](docs/REFERENCE.md) — architecture, layout, formats, and contracts.
 2. [`docs/operating-model.md`](docs/operating-model.md) — the software-engineering role model, artifact chain, and the delivery/operations gaps this workspace now names explicitly.
-3. [`docs/first-run-acceptance.md`](docs/first-run-acceptance.md) — the deterministic first-run acceptance path for onboarding and rollout checks.
-4. [`docs/examples/first-hour.md`](docs/examples/first-hour.md) — the fastest end-to-end walkthrough from install to the first useful cross-layer proof.
-5. [`docs/collaboration.md`](docs/collaboration.md) — the human collaboration contract for shared KB workspaces.
-6. [`plugins/kb/skills/kb-management/references/output-contract.md`](plugins/kb/skills/kb-management/references/output-contract.md) — the collaboration-safe response contract for auditability and handoffs.
-7. [`docs/examples/day-in-the-life.md`](docs/examples/day-in-the-life.md) — what it feels like in practice.
-8. [`plugins/kb/skills/kb-management/SKILL.md`](plugins/kb/skills/kb-management/SKILL.md) — the full behavioral spec (this IS the spec).
+3. [`docs/role-handbook.md`](docs/role-handbook.md) — the role-by-role companion to the operating model: which commands each role reaches for first, which artifacts they read and write, and one realistic chain per role.
+4. [`docs/first-run-acceptance.md`](docs/first-run-acceptance.md) — the deterministic first-run acceptance path for onboarding and rollout checks.
+5. [`docs/examples/first-hour.md`](docs/examples/first-hour.md) — the fastest end-to-end walkthrough from install to the first useful cross-layer proof.
+6. [`docs/collaboration.md`](docs/collaboration.md) — the human collaboration contract for shared KB workspaces.
+7. [`plugins/kb/skills/kb-management/references/output-contract.md`](plugins/kb/skills/kb-management/references/output-contract.md) — the collaboration-safe response contract for auditability and handoffs.
+8. [`docs/examples/day-in-the-life.md`](docs/examples/day-in-the-life.md) — what it feels like in practice for an engineer, a PM, an EM, and an on-call SRE.
+9. [`plugins/kb/skills/kb-management/SKILL.md`](plugins/kb/skills/kb-management/SKILL.md) — the full behavioral spec (this IS the spec).
 
 ## Status
 
@@ -340,6 +341,7 @@ Apache License 2.0 — see [LICENSE](LICENSE).
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-14 | Added `docs/role-handbook.md` to "Where to start" as the role-by-role companion to the operating model, and updated the `day-in-the-life` pointer to mention the new PM, EM, and on-call SRE scenes. No version-status row change yet — the retro/role-handbook bundle accumulates under `[Unreleased]` in `CHANGELOG.md` | Daily-reality gap audit across software-company roles |
 | 2026-05-10 | Rolled the public framework status to 6.0.0 after the v5 adoption-arc closeout: promoted `/kb brief`, `/kb spec`, `/kb release`, and `/kb incident` to canonical command verbs (matching the operating-model artifact chain and the templates the skill instantiates), surfaced the previously undocumented `/kb publish`, `/kb sync`, `/kb diff`, `/kb start-week`, `/kb end-day`, `/kb audit`, and `/kb report [scope]` flows in the public command list, removed the residual fixed-ladder `L1`/`L2/L3`/`L4` drift from the routing prompt and operator agent, aligned the four delivery/operations file formats in `docs/REFERENCE.md` §4 with the templates, and corrected the year-nested archive and weekly-summary paths so daily and weekly rituals write where the spec says they should | v6.0.0 adoption + daily-usage gap audit |
 | 2026-05-06 | Rolled the public framework status to 5.6.0 after adding canonical ownership semantics for promoted decisions and tasks, so adopters do not leave parallel active source and target records behind | Decision/task ownership follow-up |
 | 2026-04-30 | Rolled the public framework status to 5.5.1 after correcting the HTML landing-page value proposition so product direction, roadmaps, journeys, delivery, and operations are visible in the top-level story and first-class building blocks | HTML value-prop correction |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -1,8 +1,8 @@
 # Reference
 
-> **Version:** 6.0.0
+> **Version:** 6.1.0
 
-Implementation-critical details for building agentic-kb compatible tools. For the user guide, see [README.md](../README.md). For the software-engineering role and artifact model, see [docs/operating-model.md](./operating-model.md). For the deterministic onboarding proof, see [docs/first-run-acceptance.md](./first-run-acceptance.md) and [docs/examples/first-hour.md](./examples/first-hour.md). For the human collaboration contract in shared workspaces, see [docs/collaboration.md](./collaboration.md). For behavioral specs, read the skill and agent files directly: [`plugins/kb/skills/kb-management/SKILL.md`](../plugins/kb/skills/kb-management/SKILL.md), [`plugins/kb/skills/kb-setup/SKILL.md`](../plugins/kb/skills/kb-setup/SKILL.md), [`plugins/kb/agents/kb-operator.md`](../plugins/kb/agents/kb-operator.md).
+Implementation-critical details for building agentic-kb compatible tools. For the user guide, see [README.md](../README.md). For the software-engineering role and artifact model, see [docs/operating-model.md](./operating-model.md). For the role-by-role daily companion to the operating model, see [docs/role-handbook.md](./role-handbook.md). For the deterministic onboarding proof, see [docs/first-run-acceptance.md](./first-run-acceptance.md) and [docs/examples/first-hour.md](./examples/first-hour.md). For the human collaboration contract in shared workspaces, see [docs/collaboration.md](./collaboration.md). For behavioral specs, read the skill and agent files directly: [`plugins/kb/skills/kb-management/SKILL.md`](../plugins/kb/skills/kb-management/SKILL.md), [`plugins/kb/skills/kb-setup/SKILL.md`](../plugins/kb/skills/kb-setup/SKILL.md), [`plugins/kb/agents/kb-operator.md`](../plugins/kb/agents/kb-operator.md).
 
 ---
 
@@ -275,7 +275,7 @@ Archived ideas live under `_kb-ideas/archive/YYYY/`.
 
 ```markdown
 ---
-type: meeting | note
+type: meeting | note | retro
 date: YYYY-MM-DD
 attendees: [@alice, @bob]
 workstream: <name>
@@ -293,6 +293,36 @@ authors: [@alice]
 ```
 
 Meeting notes should be shared at multi-user layers unless the adopter intentionally configures otherwise.
+
+#### Retro variant
+
+When `type: retro`, use the retro section shape instead of the meeting shape. Retros are notes with a known structure used for sprint, project/launch, post-incident, and quarterly reflection. The retro frontmatter adds `cadence`, `facilitator`, and `period`; the body uses the sections below.
+
+```markdown
+---
+type: retro
+date: YYYY-MM-DD
+cadence: sprint | bi-weekly | project | post-launch | post-incident | quarterly
+facilitator: @name
+attendees: [@names]
+workstream: <name>
+period: <window or event the retro reflects on>
+source: <optional link>
+authors: [@names]
+---
+
+# Retro: <title>
+
+## Context
+## What went well
+## What didn't
+## What we changed already
+## What we will change
+## Open questions
+## Linked artifacts
+```
+
+Retros live under `_kb-notes/YYYY/` next to meeting notes. They do not require a new feature flag — `notes` is already the enabling feature. The template the skill instantiates is `plugins/kb/skills/kb-management/templates/retro.md`. Action items from *What we will change* must be promoted into the layer's `_kb-tasks/backlog.md` or `_kb-decisions/` before the retro is considered closed, so the session produces tracked commitments instead of dissolving into "false convergence" (see [`docs/collaboration.md`](./collaboration.md)).
 
 ### Brief (`_kb-delivery/briefs/YYYY-MM-DD-slug.md`)
 
@@ -833,6 +863,7 @@ Versioning rule: the marketplace-facing version in `.claude-plugin/marketplace.j
 
 | Date | What changed |
 |------|-------------|
+| 2026-05-14 | Added the retro variant to §4 Note formats (`type: retro` with cadence/facilitator/period frontmatter and a structured what-went-well / what-didn't / changed / will-change / open-questions / linked-artifacts section set) so sprint, project, post-launch, post-incident, and quarterly retros have a canonical shape. Retros stay inside the existing `notes` feature — no new directory or feature flag. Added a navigation pointer to the new role-handbook companion doc |
 | 2026-05-10 | Version aligned to 6.0.0 after the v5 adoption-arc closeout. Updated the §4 brief, spec, release, and incident file formats so they match the templates the skill actually instantiates: brief gains "Why now", "Success signals", "Dependencies and handoffs", and an inline changelog and moves stakeholders into the frontmatter; spec gains "Requirements", "Proposed shape", "Rollout and migration", "Verification", "Open questions", and an inline changelog and links to the originating brief in the frontmatter; release gains "Audience" and "Linked spec" frontmatter and switches to the rollout/rollback/communications/follow-up section set; incident gains "Owners", "Services", and the precise "Opened" timestamp. The four artifacts are now the same shape across REFERENCE, templates, and the new `/kb brief`, `/kb spec`, `/kb release`, and `/kb incident` verbs in `command-reference.md` |
 | 2026-05-10 | Added shared collaboration artifact guidance for status, delivery, and roadmap-change report sources |
 | 2026-05-08 | Clarified the shipped role of the draft roadmap/journey helper scripts and bumped the reference patch version |

--- a/docs/examples/day-in-the-life.md
+++ b/docs/examples/day-in-the-life.md
@@ -79,6 +79,90 @@ Suggested next steps:
   2. Use /kb report progress team-observability before the weekly sync
 ```
 
+## Three other roles, same primitives
+
+The same shapes serve very different days. These compact scenes show how a product manager, an engineering manager, and an on-call engineer use the same `/kb` surface that Alex used above.
+
+### Product manager — Priya
+
+```text
+09:00  Priya: /kb start-day
+       Agent: surfaces 2 open decisions waiting on her, 1 customer-feedback
+              finding captured overnight, and a stale roadmap-change report
+              from last week.
+
+10:30  Priya: /kb https://transcript/customer-mid-market-call
+       Agent: 4/5 — captured as finding, updated the onboarding journey's
+              step 3 readiness from "ready" to "needs evidence", proposed
+              a new brief on activation friction.
+
+13:00  Priya: /kb brief activation-friction
+       Agent: scaffolds _kb-delivery/briefs/2026-05-14-activation-friction.md
+              with problem, why-now, scope, non-goals, and success signals;
+              prompts for the outcome window.
+
+16:00  Priya: /kb report roadmap-change platform
+       Agent: opens roadmap-change source at
+              _kb-references/reports/sources/platform/roadmap-change-platform-2026-05-14.md,
+              renders the HTML, names the accountable roadmap owner for approval.
+```
+
+### Engineering manager — Eun-ji
+
+```text
+08:30  Eun-ji: /kb start-day
+       Agent: 3 reports with open blockers, 1 decision overdue (D-2026-05-08
+              missing RACI), incident I-2026-05-13-payment-latency resolved
+              overnight with 2 follow-up tasks unowned.
+
+11:00  Eun-ji: /kb decide hire-vs-internal-rotation
+       Agent: opens the decision with explicit stakeholders, due date Friday,
+              status gathering-evidence.
+
+14:30  Eun-ji: /kb note meeting weekly-product-sync
+       Agent: meeting note opens; attendees prompted; agent suggests linking
+              to the active brief and the open decision.
+
+15:30  Eun-ji: /kb report status engineering-org
+       Agent: status source written under
+              _kb-references/reports/sources/engineering-org/status-engineering-org-2026-05-14.md;
+              flags 1 workstream with last-reviewed > 14 days as stale.
+
+17:30  Eun-ji: /kb end-day
+       Agent: 1 decision moved to under-discussion, 2 follow-up tasks
+              archived after explicit confirmation, day summary committed.
+```
+
+### On-call SRE — Marek
+
+```text
+03:14  Pager fires.
+       Marek: /kb incident payment-latency
+       Agent: opens _kb-operations/incidents/2026/2026-05-13-payment-latency.md
+              with severity prompt, owners, services. Marek picks sev-2,
+              services=[payments, checkout].
+
+03:18–05:42  Marek appends timeline entries as mitigations land.
+             Agent keeps the record append-only after each update.
+
+05:50  Marek: /kb incident resolve
+       Agent: status moves to resolved; prompts for the post-incident retro
+              window (recommended within 48 hours).
+
+Next day:
+14:00  Marek: /kb note retro payment-latency
+       Agent: opens a retro note using the retro template;
+              cadence=post-incident, period=2026-05-13 03:14–05:50;
+              prompts to link the incident record.
+
+14:45  Marek: /kb note end
+       Agent: 3 action items in "What we will change" surfaced as proposed
+              tasks; 1 promoted as a decision (vendor SLA escalation);
+              no false-convergence flag since commitments are tracked.
+```
+
+The point of these three scenes is not that PMs, EMs, and SREs do the same things — they don't. The point is that the same primitives (`brief`, `decide`, `note meeting`, `note retro`, `incident`, `report status`, `report roadmap-change`) compose into very different daily shapes without forcing role-specific commands.
+
 ## Shared artifact rhythm behind the scenes
 
 In a team using roadmap and journeys seriously, Alex would usually keep three recurring shared artifacts in motion:
@@ -99,6 +183,7 @@ Alex never had to manually maintain a wiki hierarchy. The agent handled the book
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-14 | Added compact PM, EM, and on-call SRE scenes so the example covers the three non-engineer roles the operating model names alongside engineers. Introduced the post-incident retro flow in the SRE scene to exercise the new `/kb note retro [topic]` variant | Daily-reality gap audit across software-company roles |
 | 2026-05-10 | Added the shared artifact rhythm connecting status, delivery, and roadmap-change reports | Adoption-oriented engineering pass |
 | 2026-04-25 | Reworked the example for 5.0.0: anchor layer, named team layers, year-based finding paths, and explicit cross-layer promotion replaced the old fixed-ladder example | v5.0.0 flexible layer model |
 | 2026-04-18 | Initial version | Extracted from source spec §13 |

--- a/docs/operating-model.md
+++ b/docs/operating-model.md
@@ -1,8 +1,10 @@
 # Software Engineering Operating Model
 
-> **Version:** 0.2.0 | **Last updated:** 2026-04-30
+> **Version:** 0.3.0 | **Last updated:** 2026-05-14
 
 This document describes what day-to-day software engineering work looks like across the main roles in a software company, which artifacts make that work legible, and which parts of that operating model `agentic-kb` did not model explicitly before this operating-model extension.
+
+For the role-by-role companion (which commands each role reaches for first, which artifacts they read most, which they author most, and one realistic chain through the artifact graph per role), see [`docs/role-handbook.md`](./role-handbook.md).
 
 It is partly analytical and partly prescriptive:
 
@@ -19,7 +21,7 @@ In a software company, "daily work" is a mesh of five loops that happen in paral
 | Design | What should we build and how should it work? | tech lead, staff engineer, senior engineer, designer, security, QA | daily to weekly | specs, decisions, notes, linked findings |
 | Delivery | What is being built, by whom, and what is blocked? | engineers, tech leads, QA, program managers, EMs | daily | tasks, backlog, focus, release records, progress reports |
 | Operations | Is the system healthy in production, and what do we do when it is not? | SRE, on-call engineers, EMs, support, security | continuous | incidents, release records, findings, runbooks, follow-up decisions |
-| Learning | What did we learn, and how does it change future work? | everyone | continuous | findings, topics, post-incident notes, reports, updated briefs/specs |
+| Learning | What did we learn, and how does it change future work? | everyone | continuous | findings, topics, retros, post-incident notes, reports, updated briefs/specs |
 
 The important point is that knowledge systems fail when they model only the learning loop. Real engineering organizations also need the design, delivery, and operations loops to stay visible.
 
@@ -114,6 +116,18 @@ The spec described layers and collaboration, but not the concrete artifact hando
 
 Missing concept: **software engineering operating model** as a named layer above the primitive list.
 
+### Gap F: No canonical shape for team reflection
+
+The original primitive list could capture incidents and findings, but the most common learning ritual — the team retrospective, in sprint, project, post-launch, and post-incident flavors — had no structured carrier. Meeting notes were too loose for the went-well / didn't / will-change shape, and findings were the wrong granularity for a session-bounded reflection.
+
+Missing artifact: **retro** (added in v0.3.0 as a structured note variant; see [`docs/role-handbook.md`](./role-handbook.md) and §6 below).
+
+### Gap G: No user-facing role view
+
+The role table in §2 above is analytical: it lists roles, daily realities, and artifact reading/authoring patterns. Real adopters needed a usable companion that maps each role to concrete `/kb` commands they should reach for first, in a single document.
+
+Missing document: **role handbook** (added in v0.3.0 as [`docs/role-handbook.md`](./role-handbook.md)).
+
 ## 6. What This Extension Adds
 
 This extension closes those gaps with four optional feature families and six standard artifacts.
@@ -133,6 +147,7 @@ This extension closes those gaps with four optional feature families and six sta
 | Spec | Defines requirements, design shape, risks, rollout, and verification | tech lead, staff engineer, engineers | engineers, QA, security, release owners |
 | Release record | Makes rollout, verification, rollback, and communications explicit | tech lead, release owner, QA | support, on-call, EM, stakeholders |
 | Incident record | Makes impact, timeline, mitigations, and follow-up explicit | on-call, SRE, engineers | EM, support, security, leadership |
+| Retro (note variant) | Makes session-bounded team learning explicit — sprint, project, post-launch, post-incident, quarterly | facilitator (often TL, EM, SRE, designer, or PM depending on cadence) | the team, plus EM and stakeholders for cross-team or post-incident retros |
 
 These additions do not replace findings, notes, decisions, or reports. They bridge them.
 
@@ -147,6 +162,7 @@ Use the artifact that matches the question being answered:
 - use a **decision** when choosing between explicit options,
 - use a **release record** when shipping or rolling back a change,
 - use an **incident record** when runtime behavior degrades or breaks,
+- use a **retro** (note variant) when running a session-bounded reflection that should produce tracked commitments,
 - use a **finding** when preserving dated evidence,
 - use a **topic** when updating the living team position after learning.
 
@@ -169,6 +185,7 @@ Those surfaces may still feed findings, briefs, specs, releases, or incidents th
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-14 | v0.3.0: named Gap F (no canonical shape for team reflection — closed by the retro note variant) and Gap G (no user-facing role view — closed by the new `docs/role-handbook.md`). Added retros to the §1 Learning-loop artifact list and to §6's artifact table; extended the §7 modeling rule of thumb with retros. Added the top-of-doc pointer to the role handbook | Daily-reality gap audit across software-company roles |
 | 2026-04-30 | Added roadmap and journey artifacts to the role-loop model so product-management direction work is explicit alongside delivery and operations handoffs | Product-management surface integration |
 | 2026-04-26 | Initial operating-model analysis and artifact-gap definition for company-wide software engineering work; introduced the delivery/operations gap narrative for briefs, specs, releases, and incidents | Gap analysis for software-engineering daily work |
 | 2026-04-27 | Appended missing trailing newline to satisfy `markdownlint` MD047; no semantic change | CI fix |

--- a/docs/role-handbook.md
+++ b/docs/role-handbook.md
@@ -1,0 +1,305 @@
+# Role Handbook
+
+> **Version:** 0.1.0 | **Last updated:** 2026-05-14
+
+A role-by-role companion to [`docs/operating-model.md`](./operating-model.md). The operating model explains *which loops exist* and *which artifacts make them legible*; this handbook flips that view so each role can find its own daily reality, top commands, and primary artifacts in one place.
+
+This document is descriptive, not prescriptive. Real titles vary; real teams blend roles. Use the closest match and adapt.
+
+---
+
+## How to read this
+
+For each role:
+
+- **Daily reality** — the concrete shape of a working day, not a job description.
+- **Primary loop** — which of the five operating-model loops the role lives in most.
+- **Top commands** — the `/kb` flows the role reaches for first.
+- **Reads** — artifacts the role consumes daily or weekly.
+- **Writes** — artifacts the role authors directly.
+- **Typical example** — one realistic chain through the artifact graph.
+
+The artifact chain that grounds everything is:
+
+```text
+goal/workstream -> journey/brief -> roadmap/spec -> decision/task -> release -> incident -> retro/finding/topic/report
+```
+
+Every role touches some prefix or suffix of that chain. Knowing which prefix or suffix you live in is the point of this handbook.
+
+---
+
+## Product manager (PM)
+
+**Daily reality.** Customer interviews, roadmap maintenance, backlog grooming, stakeholder updates, spec/PRD drafting, cross-functional alignment (engineering, design, sales, support), metrics review, problem framing.
+
+**Primary loop.** Direction. Secondary: Learning.
+
+**Top commands.**
+
+- `/kb start-day` — focus + decision + connection deltas
+- `/kb journeys [...]` — author or refresh a journey when the active layer has a `journeys:` block
+- `/kb roadmap [...]` — reconcile plan-vs-delivery when the active layer has a `roadmap:` block
+- `/kb brief [title]` — frame the next piece of work
+- `/kb report status [scope]` / `/kb report roadmap-change [scope]` — stakeholder readouts
+- `/kb decide [description]` — open prioritization or scope decisions
+
+**Reads.** journeys, roadmaps, briefs, specs, status reports, release records, customer findings, decisions.
+
+**Writes.** journeys, briefs, decisions, roadmap-change reports, status reports, meeting notes.
+
+**Typical example.** A customer call surfaces a new pain point → `/kb https://transcript/...` captures it as a finding → the finding informs an existing journey → the PM updates the journey, opens a brief framing the new outcome window, and adds a roadmap-change report explaining why the next phase is moving up.
+
+---
+
+## Engineering manager (EM)
+
+**Daily reality.** 1:1s with reports, capacity and staffing decisions, escalation handling, performance management, hiring loops, budget conversations, status reports to leadership, incident review participation, unblocking.
+
+**Primary loop.** Direction + Delivery + Operations (the EM is the role most spread across loops).
+
+**Top commands.**
+
+- `/kb start-day` — focus + open decisions + blockers across reports
+- `/kb start-week` — full digest before Monday planning
+- `/kb decide [description]` — open staffing, escalation, or scope decisions with explicit RACI
+- `/kb report status [scope]` / `/kb report delivery [scope]` — leadership readouts
+- `/kb task` — review what's blocked across the team
+- `/kb audit` — surface contradictions, stale workstreams, missing owners
+
+**Reads.** workstreams, briefs, specs, task views, incidents, weekly reports, decisions, foundation (stakeholders).
+
+**Writes.** decisions (with RACI), workstream status updates, status/delivery reports, escalation notes, meeting notes.
+
+**Typical example.** A team is missing a target → EM digests parent strategy with `/kb digest engineering-org` → opens a decision with explicit stakeholders and due date → captures the unblocking discussion in a meeting note → archives the decision once resolved → adds the outcome to the next delivery report.
+
+**Note on people-management artifacts.** 1:1 stewardship, career conversations, and performance documentation sit outside the spec's first-class primitives (see `operating-model.md` §8). Many EMs keep these in private contributor-scoped meeting notes or in a separate HR system; the KB is not a replacement for either.
+
+---
+
+## Staff / principal engineer
+
+**Daily reality.** Architecture work, cross-team alignment, design reviews, mentoring senior engineers, escalations on technical risk, roadmap inputs, deep technical investigation, occasional implementation on critical paths.
+
+**Primary loop.** Design. Secondary: Direction.
+
+**Top commands.**
+
+- `/kb spec [title]` — turn briefs into design contracts
+- `/kb decide [description]` — open architecture decisions with linked evidence
+- `/kb [text/URL]` — capture papers, prototypes, and post-mortems as findings
+- `/kb promote [file] [layer]` — surface durable findings or specs upward
+- `/kb report progress [scope]` — synthesize across workstreams
+- `/kb audit` — surface drift between specs and reality
+
+**Reads.** briefs, specs, decisions, incidents, findings, journeys, parent-layer strategy digests.
+
+**Writes.** specs, decisions, findings, design notes.
+
+**Typical example.** A new initiative lands as a brief → staff engineer writes a spec linking it, opens an architecture decision with options A/B/C, gathers evidence findings from prototypes and prior incidents → resolves the decision, marks the spec `accepted`, and promotes it to the team layer.
+
+---
+
+## Tech lead
+
+**Daily reality.** Turn intent into implementable plans, run refinement and design discussions, review PRs, mentor engineers, own a workstream end-to-end, coordinate rollouts.
+
+**Primary loop.** Design + Delivery.
+
+**Top commands.**
+
+- `/kb spec [title]` — design contracts
+- `/kb brief [title]` — when intent needs to be sharpened before spec work
+- `/kb release [title]` — own the rollout record for the team's changes
+- `/kb decide [description]` — design forks and rollout choices
+- `/kb note meeting [topic]` — refinement and review sessions
+- `/kb start-week` / `/kb end-week` — keep the workstream legible
+
+**Reads.** briefs, specs, tasks, release records, parent decisions, journeys covering the workstream.
+
+**Writes.** specs, decisions, release records, meeting notes, focus task updates.
+
+**Typical example.** Brief lands → tech lead writes spec → opens release record with rollout/rollback/verification plan → ships → release record links the follow-up finding when a small regression appears → finding informs the next spec revision.
+
+---
+
+## Engineer (IC)
+
+**Daily reality.** Standup, PR review (giving and receiving), implementing against specs/tickets, writing tests, debugging, async chat clarifications, occasional on-call rotation, learning time.
+
+**Primary loop.** Delivery. Secondary: Learning.
+
+**Top commands.**
+
+- `/kb start-day` — see today's focus task
+- `/kb task` / `/kb task done [item]` — drive personal focus
+- `/kb [text/URL/path]` — capture a paper, post, or code-review insight worth keeping
+- `/kb note [text]` — quick working notes during debugging
+- `/kb idea [text]` / `/kb develop [idea]` — seed and spar on improvements
+- `/kb end-day` — wrap, archive done items, commit
+
+**Reads.** specs, tasks, decisions linked to active work, recent incidents, runbooks, parent strategy digests.
+
+**Writes.** findings, working notes, tasks, idea seeds, occasional decision evidence.
+
+**Typical example.** Hits an unfamiliar failure mode while debugging → `/kb` the relevant doc and the stack trace → finding gets `Gate 3/5` and updates the reliability topic → adds a follow-up task to harden the test → the test PR closes the task, end-of-day archives it.
+
+---
+
+## Designer / researcher
+
+**Daily reality.** User interviews and synthesis, wireframes and prototypes, design reviews and critique, design-system upkeep, working alongside PM and engineering, usability testing, handoff.
+
+**Primary loop.** Direction + Learning.
+
+**Top commands.**
+
+- `/kb journeys [...]` — author or refresh persona journeys on the layer that owns them
+- `/kb [text/URL]` — capture interview snippets, synthesis, references
+- `/kb note meeting [topic]` — design reviews and research debriefs
+- `/kb brief [title]` — frame design problems when ownership warrants it
+- `/kb report progress [scope]` — research roll-ups for a workstream
+- `/kb develop [idea]` — sparring on design directions
+
+**Reads.** briefs, specs, journey artifacts, research findings, customer feedback reports.
+
+**Writes.** journeys, briefs (collaboratively with PM), findings, design notes, meeting notes.
+
+**Typical example.** Three user interviews surface the same friction → `/kb` captures each as a finding tagged to the persona journey → the journey gets a readiness drop on the affected step → PM and designer co-author a brief; designer prototypes; finding chain feeds the spec.
+
+---
+
+## QA / test engineer
+
+**Daily reality.** Test plan writing, manual and exploratory testing, test automation, bug triage and reporting, release verification and sign-off, regression maintenance.
+
+**Primary loop.** Delivery + Learning.
+
+**Top commands.**
+
+- `/kb spec [title]` — sometimes co-authored to capture verification approach
+- `/kb release [title]` — own or co-own the release verification section
+- `/kb [text/URL]` — capture flaky-test patterns, regression evidence
+- `/kb note retro [topic]` — post-release retros (see [retro](#retrospective-pattern) pattern below)
+- `/kb task` — track verification items
+- `/kb report delivery [scope]` — readiness summary alongside engineering owners
+
+**Reads.** specs, release records, recent incidents, findings tagged to flaky areas.
+
+**Writes.** test plan notes, verification entries on release records, findings, retros.
+
+**Typical example.** Spec lands with a verification section → QA writes test plan as a working note → executes; one failure mode becomes a finding → release record's verification section links the finding and proceeds with mitigation noted in the rollout plan.
+
+---
+
+## SRE / on-call engineer
+
+**Daily reality.** Dashboard and alert monitoring, incident response, postmortems, capacity planning, reliability work (SLOs, error budgets), on-call rotation handoff, runbook upkeep.
+
+**Primary loop.** Operations + Learning.
+
+**Top commands.**
+
+- `/kb incident [title]` — open the timeline record at first sign of degradation
+- `/kb start-day` — review overnight alerts and any active incidents
+- `/kb note retro [topic]` — run the post-incident retro
+- `/kb [text/URL]` — capture symptom patterns, change correlations, runbook gaps as findings
+- `/kb decide [description]` — open follow-up decisions surfaced by incidents
+- `/kb report status [scope]` — communicate to stakeholders during incidents and after
+
+**Reads.** incidents (open + recent), release records (especially in the last 24 hours), runbooks, decisions tagged to reliability, parent operations digests.
+
+**Writes.** incidents (live updates → append-only after resolution), retros, findings, runbook updates, follow-up tasks.
+
+**Typical example.** Alert fires → `/kb incident db-latency-spike` opened with severity and owner → timeline updated as mitigations land → resolved → `/kb note retro db-latency-spike` runs the team retro → action items become tasks linked back to the incident; one becomes a spec for a permanent fix.
+
+---
+
+## Security / compliance engineer
+
+**Daily reality.** Threat modeling, vulnerability triage, security review of changes, audit and compliance evidence collection, incident response participation, policy upkeep.
+
+**Primary loop.** Operations + Design + Learning.
+
+**Top commands.**
+
+- `/kb [text/URL]` — capture advisories, threat-intel notes, audit findings
+- `/kb decide [description]` — open control or risk-acceptance decisions
+- `/kb spec [title]` — co-author specs that need security-review sections
+- `/kb incident [title]` — open security incidents
+- `/kb audit` — surface drift between policy and observed state
+- `/kb report status [scope]` — security posture readouts
+
+**Reads.** specs (especially "Risks and trade-offs"), incidents, release records, decisions tagged to security, compliance digests from parent layers.
+
+**Writes.** findings (threat intel, vuln advisories), decisions (control changes), review notes, security incident records.
+
+**Typical example.** New advisory matches a dependency in the workstream → capture as finding → open decision: patch now vs. compensating control → resolution links spec changes and a release record describing the rollout.
+
+---
+
+## Data / analytics
+
+**Daily reality.** Metric definitions, dashboard authoring, A/B test analysis, data quality investigations, insight reports for product and leadership.
+
+**Primary loop.** Learning + Direction.
+
+**Top commands.**
+
+- `/kb [text/URL]` — capture analyses, anomaly reports, A/B results
+- `/kb decide [description]` — when a metric definition or experiment outcome should be canonized
+- `/kb report progress [scope]` — insight roll-ups
+- `/kb note meeting [topic]` — metric review meetings
+
+**Reads.** journeys (to ground metrics in user behavior), briefs (success signals), recent releases (to attribute movement).
+
+**Writes.** findings (insights), decisions (metric definitions), reports, occasional spec contributions.
+
+**Typical example.** A/B test resolves → finding captures the result with linked dashboards → existing decision on feature rollout moves from `under-discussion` to `decided` citing the finding → product brief's success signals section is updated.
+
+---
+
+## Retrospective pattern
+
+Retrospectives are the most common learning ritual that previously had no canonical shape in the spec. Use the `retro` note variant when a recurring team reflection or a one-off project debrief needs to be durable:
+
+- **Sprint / iteration retros** — recurring team reflection
+- **Project / launch retros** — at the end of a bounded effort
+- **Post-incident retros** — within days of incident resolution, paired with the incident record
+- **Quarterly or annual retros** — broader cadences for leadership or whole-team learning
+
+Mechanically, a retro is a meeting note with a known structure:
+
+| Section | Question it answers |
+|---------|--------------------|
+| Context | What period or event are we reviewing? |
+| What went well | What should we keep doing? |
+| What didn't | What hurt us? |
+| What we changed already | Mid-flight corrections worth preserving |
+| What we will change | Concrete commitments — these become tasks or decisions |
+| Open questions | Things we couldn't resolve in the session |
+| Linked artifacts | Incidents, releases, briefs, specs the retro reflects on |
+
+Open one with `/kb note retro [topic]`. The template lives at [`plugins/kb/skills/kb-management/templates/retro.md`](../plugins/kb/skills/kb-management/templates/retro.md). Action items in *What we will change* should be promoted into the team layer's `_kb-tasks/backlog.md` or `_kb-decisions/` immediately — a retro that produces no tracked commitments is one of the failure modes [collaboration.md](./collaboration.md) flags as "false convergence".
+
+---
+
+## Reading this back into the operating model
+
+| Operating-model loop | Roles primarily here |
+|----------------------|----------------------|
+| Direction | PM, EM, staff engineer, designer |
+| Design | Staff engineer, tech lead, designer (for UX contracts), security |
+| Delivery | Engineer, tech lead, QA, EM |
+| Operations | SRE / on-call, EM, security, support |
+| Learning | Everyone — the retro pattern, findings, and topic updates are the connective tissue |
+
+No role lives in one loop. The handbook lists where each role spends the most time, not where it is restricted to.
+
+---
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-05-14 | Initial role handbook covering PM, EM, staff/principal engineer, tech lead, engineer, designer, QA, SRE/on-call, security, data; introduced the retrospective pattern as a note variant tied to `_kb-notes/` with a dedicated template | Daily-reality gap audit across software-company roles |

--- a/plugins/kb/skills/kb-management/SKILL.md
+++ b/plugins/kb/skills/kb-management/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kb-management
-description: Lean, layered knowledge management driven by the `/kb` command. Operates on a flexible layer graph, applies the five-question evaluation gate, tracks findings, notes, decisions, ideas, tasks, briefs, specs, releases, and incidents as first-class artifacts, digests connected repos and trackers, and publishes reusable skills to per-layer marketplaces.
-version: 6.0.0
+description: Lean, layered knowledge management driven by the `/kb` command. Operates on a flexible layer graph, applies the five-question evaluation gate, tracks findings, notes (including retros), decisions, ideas, tasks, briefs, specs, releases, and incidents as first-class artifacts, digests connected repos and trackers, and publishes reusable skills to per-layer marketplaces.
+version: 6.1.0
 triggers:
   # Command surface
   - "/kb"
@@ -45,6 +45,12 @@ triggers:
   # Note / idea / task verbs
   - "note"
   - "meeting note"
+  - "retro"
+  - "retrospective"
+  - "post-mortem"
+  - "postmortem"
+  - "sprint retro"
+  - "post-incident retro"
   - "idea"
   - "develop idea"
   - "sparring session"
@@ -158,7 +164,7 @@ Full command reference: `references/command-reference.md`.
 | Diff | `/kb diff [layer]` | Show new material per contributor or connection |
 | Migrate | `/kb migrate archives` / `/kb migrate layer-model` | Preview or apply legacy archive and layer-model migrations |
 | Task | `/kb task` / `/kb task done [item]` | Manage focus/backlog |
-| Note | `/kb note [text]` / `/kb note meeting [topic]` / `/kb note end` | Capture general or meeting notes and surface follow-on changes |
+| Note | `/kb note [text]` / `/kb note meeting [topic]` / `/kb note retro [topic]` / `/kb note end` | Capture general, meeting, or retro notes and surface follow-on changes. The retro variant uses the structured what-went-well / what-didn't / changed / will-change / open-questions / linked-artifacts shape and must produce tracked commitments (tasks or decisions) before it is considered closed |
 | Idea | `/kb idea [text]` | Create a seed idea |
 | Develop | `/kb develop [idea]` | Spar on assumptions, contradictions, and convergence |
 | Decide | `/kb decide [desc]` / `/kb decide resolve [D-id]` | Open or resolve a decision |
@@ -223,7 +229,7 @@ When the selected target is `role: consumer`, refuse and point to the next valid
 
 The templates this skill instantiates live in `templates/`:
 
-- `finding.md`, `topic.md`, `decision.md`, `idea.md`, `note.md`, `workstream.md`
+- `finding.md`, `topic.md`, `decision.md`, `idea.md`, `note.md`, `retro.md`, `workstream.md`
 - `brief.md`, `spec.md`, `release.md`, `incident.md`
 - `focus.md`, `backlog.md`
 - `index.html`, `artifact-base.html`, `report.html`
@@ -246,6 +252,7 @@ The templates this skill instantiates live in `templates/`:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-14 | v6.1.0: added the retro note variant. `/kb note retro [topic]` now opens a structured retrospective using the new `templates/retro.md` shape (sprint, project/launch, post-incident, quarterly cadences). Retros stay inside the `notes` feature — no new directory or feature flag — and must produce tracked commitments (tasks or decisions) before they are considered closed. Added retro/retrospective/post-mortem trigger phrases so natural-language invocations route here. Workstream template enriched with Owner, Status, Cadence, Last reviewed, Linked briefs/specs, Recent shipments, and Upcoming milestones | Daily-reality gap audit across software-company roles |
 | 2026-05-10 | v6.0.0: promoted `/kb brief`, `/kb spec`, `/kb release`, and `/kb incident` to canonical flow primitives in the layer-aware flow table so the four operating-model artifacts have discoverable command verbs (the trigger keywords were already declared, but the verb path was implicit). Each verb requires the matching `delivery` or `operations` feature on the target layer; the skill refuses cleanly if it is not enabled. No changes to gate scoring, promote/publish/digest semantics, the layer-graph rules, or any other behavioral contract | v6.0.0 adoption + daily-usage gap audit |
 | 2026-05-06 | Version aligned to 5.6.0 after adding the decision/task promotion ownership rule: promoted decisions and tasks now get one canonical owning layer, and source-layer records are closed or archived unless their scope genuinely differs | Decision/task ownership follow-up |
 | 2026-04-30 | Version aligned to 5.5.0 after making roadmap and journey work a setup-proposed product-management surface. Added natural-language product roadmap/journey triggers and clarified that missing config should route to setup/placement rather than silent scaffolding | Product-management surface integration |

--- a/plugins/kb/skills/kb-management/references/command-reference.md
+++ b/plugins/kb/skills/kb-management/references/command-reference.md
@@ -15,9 +15,12 @@
 |-----------|--------|
 | `/kb note [text]` | Create a general note under `_kb-notes/YYYY/MM-DD-slug.md` |
 | `/kb note meeting [topic]` | Start a meeting note and prompt for attendees |
+| `/kb note retro [topic]` | Start a retrospective note using `templates/retro.md`; prompts for cadence (sprint / project / post-launch / post-incident / quarterly), facilitator, attendees, the period under review, and linked artifacts (incidents, releases, briefs, specs) |
 | `/kb note end` | Close the current note, propose decisions/tasks/topic updates, and log the result |
 
 Notes use a lighter gate than findings. They are cheap capture surfaces that feed decisions, tasks, roadmap updates, and later findings without pretending to be immutable evidence.
+
+Retro variants have one additional contract: `/kb note end` on a retro must surface every action item from *What we will change* as a proposed task on the layer's `_kb-tasks/backlog.md`, or as a new decision if the item is a fork rather than a commitment. A retro that closes without any tracked commitments is flagged in the response under Gate notes as a likely "false convergence" (see [`docs/collaboration.md`](../../../../../docs/collaboration.md)); the agent does not silently fix this — the user is asked to confirm whether the retro really had no follow-ups.
 
 ## Decisions & Tasks
 
@@ -209,6 +212,7 @@ See `output-contract.md` for the full wording contract and examples.
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-14 | Added `/kb note retro [topic]` as a third note variant alongside general and meeting notes. Retros use the structured template at `plugins/kb/skills/kb-management/templates/retro.md`, must produce tracked commitments at close time, and surface a "false convergence" Gate note if they close without any. No new feature flag or directory — retros live inside the existing `notes` feature | Daily-reality gap audit across software-company roles |
 | 2026-05-10 | Added a dedicated Delivery & Operations subcommand section (`/kb brief`, `/kb spec`, `/kb release`, `/kb incident`) so the four operating-model artifacts have canonical command verbs that match the file paths in `docs/REFERENCE.md` §3 and the templates in `plugins/kb/skills/kb-management/templates/`. Each verb requires the matching `delivery` or `operations` feature on the target layer and refuses cleanly when the feature is not enabled. They were already wired as feature-keyword triggers in the kb-management skill but had no discoverable verb, which forced users to rely on natural-language intent matching | v6.0.0 adoption + daily-usage gap audit |
 | 2026-05-10 | Added explicit shared report variants for status, delivery, and roadmap-change collaboration flows | Adoption-oriented engineering pass |
 | 2026-05-06 | Clarified that `/kb promote` must keep decisions and tasks canonical to one owning layer instead of leaving parallel active source and target records | Decision/task ownership follow-up |

--- a/plugins/kb/skills/kb-management/templates/retro.md
+++ b/plugins/kb/skills/kb-management/templates/retro.md
@@ -1,0 +1,41 @@
+---
+type: retro
+date: {{DATE}}
+cadence: {{CADENCE}}
+facilitator: {{FACILITATOR}}
+attendees: {{ATTENDEES}}
+workstream: {{WORKSTREAM}}
+period: {{PERIOD}}
+source: {{SOURCE}}
+authors: {{AUTHORS}}
+---
+
+# Retro: {{TITLE}}
+
+## Context
+
+{{CONTEXT}}
+
+## What went well
+
+{{WENT_WELL}}
+
+## What didn't
+
+{{DIDNT_GO_WELL}}
+
+## What we changed already
+
+{{CHANGED_ALREADY}}
+
+## What we will change
+
+{{WILL_CHANGE}}
+
+## Open questions
+
+{{QUESTIONS}}
+
+## Linked artifacts
+
+{{LINKS}}

--- a/plugins/kb/skills/kb-management/templates/workstream.md
+++ b/plugins/kb/skills/kb-management/templates/workstream.md
@@ -1,8 +1,13 @@
 # Workstream: {{NAME}}
 
+**Owner**: {{OWNER}}
+**Status**: {{STATUS}}
+**Cadence**: {{CADENCE}}
+**Last reviewed**: {{LAST_REVIEWED}}
 **Themes**: {{THEMES}}
 **Active decisions**: {{ACTIVE_DECISIONS}}
 **Key topics**: {{KEY_TOPICS}}
+**Linked briefs / specs**: {{DELIVERY_LINKS}}
 
 ## Current State
 
@@ -11,6 +16,18 @@
 ## Active Threads
 
 {{ACTIVE_THREADS}}
+
+## Recent shipments
+
+| Date | Release / change | Link |
+|------|------------------|------|
+| {{SHIPMENT_DATE}} | {{SHIPMENT_WHAT}} | {{SHIPMENT_LINK}} |
+
+## Upcoming milestones
+
+| Target date | What | Owner |
+|-------------|------|-------|
+| {{MILESTONE_DATE}} | {{MILESTONE_WHAT}} | {{MILESTONE_OWNER}} |
 
 ## Cross-Workstream Dependencies
 


### PR DESCRIPTION
## Why

Audited the spec against the daily reality of typical software-company roles (product manager, engineering manager, staff/principal engineer, tech lead, engineer, designer, QA, SRE/on-call, security, data) and surfaced four concrete gaps:

1. **No user-facing role view** — `operating-model.md` is the analytical view of roles → loops → artifacts. There was nowhere a PM, EM, or on-call SRE could find their top 5 commands and primary artifacts in one usable doc.
2. **No carrier for retrospectives** — the most common learning ritual (sprint retro, project retro, post-launch retro, post-incident retro) had no canonical shape. Meeting notes were too loose; findings were the wrong granularity.
3. **`workstream.md` was too thin** — 17 lines without Owner, Status, Cadence, Last reviewed, Recent shipments, or Upcoming milestones is inadequate for a primary, long-running org unit.
4. **`day-in-the-life.md` only showed one role** — the example was a principal engineer; PM, EM, and on-call SRE (the three roles the operating model names alongside engineers) had no lived walkthrough.

Out of scope by design (mentioned in role-handbook): 1:1 / career artifacts (HR boundary per `operating-model.md` §8), code-review aggregates (GitHub-owned), standup snapshots (covered by `start-day`).

## What changed

**Added**
- `docs/role-handbook.md` — role-by-role companion to the operating model. PM, EM, staff/principal engineer, tech lead, engineer, designer, QA, SRE/on-call, security, and data each get daily reality, primary loop, top commands, reads, writes, and one realistic chain through the artifact graph. Closes the operating model's new Gap G.
- `/kb note retro [topic]` — structured retrospective note variant. Template at `plugins/kb/skills/kb-management/templates/retro.md` with sections: Context, What went well, What didn't, What we changed already, What we will change, Open questions, Linked artifacts. Stays inside the existing `notes` feature (no new directory or feature flag). A retro that closes without any tracked commitment surfaces a "false convergence" Gate-note warning instead of silently filing. Closes the operating model's new Gap F.
- Three new day-in-the-life scenes — Priya (PM), Eun-ji (EM), Marek (on-call SRE) alongside the existing Alex (principal engineer) walkthrough. The SRE scene exercises the new `/kb note retro` variant after a sev-2 incident.

**Changed**
- `workstream.md` template enriched with Owner, Status, Cadence, Last reviewed, Linked briefs/specs, Recent shipments (table), Upcoming milestones (table).
- `operating-model.md` → **v0.3.0**: named Gap F + Gap G, added retros to the Learning loop, §6 artifact table, and §7 modeling rule of thumb.
- `docs/REFERENCE.md` → **v6.1.0**: §4 Note format declares the retro variant (frontmatter + section set).
- `plugins/kb/skills/kb-management/SKILL.md` → **v6.1.0**: description, Note flow row, template list, trigger phrases (retro / retrospective / post-mortem / postmortem / sprint retro / post-incident retro).
- `AGENTS.md` → **v0.10**; `CHANGELOG.md` `[Unreleased]` entries.

Backward compatibility: fully additive. No new feature flag, no new directory, no breaking change to existing primitives or command verbs.

## CI

- `python3 scripts/check_consistency.py` — OK
- `python3 scripts/check_plugin_structure.py` — OK (4 skills, 1 agent)
- `npx markdownlint-cli2 "docs/**/*.md" "*.md"` — 0 errors
- `python3 scripts/generate_plugins.py` — idempotent against this branch

## Test plan

- [x] All four CI checks pass locally
- [x] All internal markdown links resolve (consistency check)
- [x] Per-file changelogs updated (AGENTS rule 3)
- [x] Root `CHANGELOG.md` `[Unreleased]` updated
- [x] No new vendor-specific terms introduced
- [x] No new feature flag, directory, or breaking command surface change

https://claude.ai/code/session_01DiHKkamCqvrcL8xXQViXZb

---
_Generated by [Claude Code](https://claude.ai/code/session_01DiHKkamCqvrcL8xXQViXZb)_