### PR TITLE
Fix README capture command reference (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
+- **README first command (#117)** — replaced the non-canonical `/kb capture [text/URL/path]` shortlist entry with the canonical `/kb [text/URL/path]`, matching `command-reference.md` and the dispatcher routing surface.
 - **Lychee local compatibility** — adjusted the dead-link config so local Lychee versions that do not accept `include_fragments = false` can parse it, disabled local cache artifacts, and excluded the generated workspace `index.html` template whose relative links are valid only after setup renders it into an adopter KB.
 
 ## [6.1.0] — 2026-05-15

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ There is exactly one user-facing command: **`/kb`**. The core plugin ships stabl
 **Most used (start here).** New adopters do not need to learn the full surface to get value. After `/kb setup`, the wizard emits a curated 3–5 command shortlist tailored to your adoption stage. The five you'll use first in almost every setup:
 
 ```
-/kb capture [text/URL/path]   → file something into the KB through the evaluation gate
+/kb [text/URL/path]           → file something into the KB through the evaluation gate
 /kb note meeting [topic]      → start a meeting note (also: /kb note retro [topic])
 /kb decide [description]      → open a decision
 /kb start-day                 → morning briefing


### PR DESCRIPTION
## What changed

- Replaced the README "Most used (start here)" capture example with the canonical `/kb [text/URL/path]` form.
- Added an Unreleased changelog entry for #117.

## Why

The README previously led new adopters to copy `/kb capture [text/URL/path]`, but `capture` is not a canonical dispatcher subcommand. The canonical capture path is bare `/kb` with the input.

## Impact

New adopters now see a first command that matches `command-reference.md` and the dispatcher routing surface. No command surface or runtime behavior changes.

## Validation

- `npx markdownlint-cli2 "docs/**/*.md" "*.md"`
- `python3 scripts/check_consistency.py`
- `docker run --rm -v "$PWD:/input:ro" -w /input lycheeverse/lychee:latest --config .lychee.toml --no-progress --verbose .`

Closes #117.
