### PR TITLE
Fix day-in-the-life version drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
+- **Day-in-the-life version drift (#122)** — `docs/examples/day-in-the-life.md` now carries the v6.1.0 header after a command-surface verification pass. The walkthrough makes the external-read preflight explicit and uses the canonical `/kb incident [title]` update flow instead of an undocumented incident-resolve shorthand. `scripts/check_consistency.py` now fails when a markdown file's version header is older than the current framework minor version unless the file is narrowly allowlisted as independently versioned or intentionally pinned.
 - **Release-readiness audit closeout** — version surfaces now agree on v6.1.0 across `VERSION`, manifests, README, and the visual landing page; first-run acceptance now covers delivery/operations and retro notes; and the product-management roadmap/journey command surface is documented as stable setup-proposed functionality rather than an unfinished add-on.
 - **Manifest version drift guard** — `scripts/check_consistency.py` now fails when the root marketplace manifest, Claude marketplace manifest, or generated per-plugin manifest drift from `VERSION`, keeping release metadata aligned in CI.
 - **GitHub Pages release build** — the repository now ships `.nojekyll` so the static landing page deploy does not interpret intentional skill/template tokens as Liquid expressions.

--- a/docs/examples/day-in-the-life.md
+++ b/docs/examples/day-in-the-life.md
@@ -1,6 +1,6 @@
 # Example: Day in the Life
 
-> **Version:** 5.0.0 | **Last updated:** 2026-05-10
+> **Version:** 6.1.0 | **Last updated:** 2026-05-24
 
 An illustrative walkthrough of a single day for a user named Alex, a principal engineer working on an observability platform. Alex has one anchor layer, two shared team layers, and consumes company guidance from a consumer layer. The examples below are not normative; they show what the system feels like in practice.
 
@@ -25,7 +25,7 @@ Suggested next steps:
 Alex: /kb https://example.org/papers/coordination-patterns
 
 Agent:
-What I did: Captured the paper as an anchor-layer finding after fetching the external URL.
+What I did: Prepared an external-read preflight for the paper URL; after Alex confirmed the fetch, captured the paper as an anchor-layer finding.
 Where it went: wrote _kb-references/findings/2026/2026-04-18-coordination-patterns.md, updated the reliability topic, and refreshed index.html + dashboard.html.
 Gate notes: 4/5 — externally fetched, informs D-2026-04-18, actionable, durable signal.
 Suggested next steps:
@@ -145,9 +145,10 @@ The same shapes serve very different days. These compact scenes show how a produ
 03:18–05:42  Marek appends timeline entries as mitigations land.
              Agent keeps the record append-only after each update.
 
-05:50  Marek: /kb incident resolve
-       Agent: status moves to resolved; prompts for the post-incident retro
-              window (recommended within 48 hours).
+05:50  Marek: /kb incident payment-latency
+       Agent: appends the mitigation summary and moves status to resolved;
+              prompts for the post-incident retro window (recommended within
+              48 hours).
 
 Next day:
 14:00  Marek: /kb note retro payment-latency
@@ -183,6 +184,7 @@ Alex never had to manually maintain a wiki hierarchy. The agent handled the book
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-24 | Verified the walkthrough against the v6.1 command reference, bumped the example version to 6.1.0, made the external-read preflight explicit, and replaced the undocumented incident-resolve shorthand with the canonical `/kb incident [title]` update flow | Issue #122 |
 | 2026-05-14 | Added compact PM, EM, and on-call SRE scenes so the example covers the three non-engineer roles the operating model names alongside engineers. Introduced the post-incident retro flow in the SRE scene to exercise the new `/kb note retro [topic]` variant | Daily-reality gap audit across software-company roles |
 | 2026-05-10 | Added the shared artifact rhythm connecting status, delivery, and roadmap-change reports | Adoption-oriented engineering pass |
 | 2026-04-25 | Reworked the example for 5.0.0: anchor layer, named team layers, year-based finding paths, and explicit cross-layer promotion replaced the old fixed-ladder example | v5.0.0 flexible layer model |

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -23,11 +23,24 @@ IGNORED_PATH_PARTS = {".git", "node_modules", ".venv", "venv", "__pycache__"}
 LONG_LIVED_DIRS: list[Path] = []
 OPTIONAL_LONG_LIVED = [REPO / "docs" / "REFERENCE.md", REPO / "docs" / "glossary.md"]
 
-# Files that are allowed to not have a version header — narrative walkthroughs,
-# examples, and standalone index files.
+# Files that are allowed to not have a version header.
 EXEMPT_FROM_VERSION = {
-    REPO / "docs" / "examples" / "day-in-the-life.md",
     REPO / "docs" / "roadmap.md",
+}
+
+# Files whose version headers intentionally track a local document contract
+# instead of the aggregate framework VERSION. Narrative examples that teach
+# current behavior should not be added here unless they are deliberately
+# release-pinned and the pin is named in the file.
+VERSION_MINOR_DRIFT_ALLOWLIST = {
+    REPO / "AGENTS.md",
+    REPO / "CLAUDE.md",
+    REPO / "docs" / "glossary.md",
+    REPO / "docs" / "operating-model.md",
+    REPO / "docs" / "role-handbook.md",
+    REPO / "docs" / "uninstall.md",
+    REPO / "plugins" / "kb" / "skills" / "kb-setup" / "references" / "adoption-stages.md",
+    REPO / "plugins" / "kb" / "skills" / "kb-setup" / "references" / "github-governance-profile.md",
 }
 
 # Terms we forbid in the public spec.
@@ -53,7 +66,7 @@ def _load_external_blocklist() -> list[str]:
         terms.append(line.lower())
     return terms
 
-VERSION_RE = re.compile(r"\*\*Version:\*\*\s*(\d+)\.(\d+)")
+VERSION_RE = re.compile(r"\*\*Version:\*\*\s*(\d+)\.(\d+)(?:\.(\d+))?")
 CHANGELOG_RE = re.compile(r"^##\s+Changelog\s*$", re.MULTILINE)
 HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
 INLINE_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
@@ -75,6 +88,13 @@ def iter_all_docs():
         if any(part in IGNORED_PATH_PARTS for part in p.parts):
             continue
         yield p
+
+
+def parse_version(value: str) -> tuple[int, int, int] | None:
+    match = re.fullmatch(r"(\d+)\.(\d+)\.(\d+)", value.strip())
+    if not match:
+        return None
+    return tuple(int(part) for part in match.groups())
 
 
 def normalize_anchor(text: str) -> str:
@@ -102,6 +122,32 @@ def check_versions_and_changelogs() -> list[str]:
             errors.append(f"MISSING **Version:** field: {rel}")
         if not CHANGELOG_RE.search(text):
             errors.append(f"MISSING '## Changelog' section: {rel}")
+
+    root_version_path = REPO / "VERSION"
+    if not root_version_path.is_file():
+        return errors
+    root_version = parse_version(root_version_path.read_text(encoding="utf-8"))
+    if root_version is None:
+        return errors
+    root_minor = root_version[:2]
+
+    for doc in iter_all_docs():
+        if doc in VERSION_MINOR_DRIFT_ALLOWLIST:
+            continue
+        text = doc.read_text(encoding="utf-8", errors="ignore")
+        match = VERSION_RE.search(text)
+        if not match:
+            continue
+        doc_minor = (int(match.group(1)), int(match.group(2)))
+        if doc_minor < root_minor:
+            rel = doc.relative_to(REPO)
+            doc_version = ".".join(part for part in match.groups() if part is not None)
+            errors.append(
+                f"VERSION header drift in {rel}: expected at least "
+                f"{root_minor[0]}.{root_minor[1]}.x, got {doc_version}. "
+                "Add a narrow allowlist entry only for intentionally pinned "
+                "or independently versioned docs."
+            )
     return errors
 
 


### PR DESCRIPTION
## Summary
- Bump `docs/examples/day-in-the-life.md` to v6.1.0 after checking the scenes against the current command reference
- Make the external-read preflight explicit and replace the undocumented incident-resolve shorthand with the canonical `/kb incident [title]` update flow
- Add a consistency guard that fails markdown version headers older than the current framework minor unless narrowly allowlisted

## Validation
- `python3 scripts/check_consistency.py`
- `npx --yes markdownlint-cli2 "docs/**/*.md" "*.md"`
- `python3 -m py_compile scripts/check_consistency.py`
- `git diff --check`

`lychee --config .lychee.toml .` could not run locally because `lychee` is not installed in this environment; CI uses `lycheeverse/lychee-action@v2`.

Closes #122