### PR TITLE
Fix install wrapper usage for #120

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -2,9 +2,11 @@
 # Install agentic-kb skills + agent into the selected harness.
 #
 # Usage:
-#   scripts/install [--target claude|opencode|vscode|all] [--global] [--force] [skill...]
+#   scripts/install [--target claude|opencode|vscode|codex|gemini|kiro|all|auto] \
+#                   [--global] [--force] [--uninstall] [skill...]
 #
-# Default: --target all, installs all declared skills + agents.
+# Default: --target auto (detects the harness from the workspace).
+# Run --target all for cross-harness install.
 #
 # On POSIX, installs are symlinks so the marketplace can update in place.
 # On Windows, installs are copies (see scripts/install.py).


### PR DESCRIPTION
## What changed
- Updated `scripts/install` header usage to list all supported targets: `claude`, `opencode`, `vscode`, `codex`, `gemini`, `kiro`, `all`, and `auto`.
- Documented `--uninstall`, the `--target auto` default, and `--target all` for cross-harness installs.

## Why
The wrapper comment lagged behind `scripts/install.py`, making supported README install paths look unsupported when adopters checked the wrapper documentation.

## Validation
- `scripts/install --help`
- `python3 scripts/check_consistency.py`
- `npx markdownlint-cli2 "docs/**/*.md" "*.md"`

`lychee --config .lychee.toml .` could not run locally because `lychee` is not installed in this environment.

Closes #120