### PR TITLE
[codex] Fix CODEOWNERS plugin paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,9 +10,11 @@
 /docs/                     @spec-editors @maintainers
 
 # Reference implementation
-/skills/                   @skill-authors @maintainers
-/agents/                   @skill-authors @maintainers
 /plugins/                  @maintainers
+/plugins/kb/utils/         @maintainers
+/plugins/kb/commands/      @maintainers
+/plugins/kb/skills/        @skill-authors @maintainers
+/plugins/kb/agents/        @skill-authors @maintainers
 /scripts/                  @maintainers
 
 # CI / release plumbing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
+- **CODEOWNERS plugin paths (#119)** — replaced stale root `/skills/` and `/agents/` ownership globs with the current `plugins/kb/skills/` and `plugins/kb/agents/` layout, keeping those specific rules after the broad `/plugins/` rule so skill and agent edits route to `@skill-authors` when those teams exist.
 - **README first command (#117)** — replaced the non-canonical `/kb capture [text/URL/path]` shortlist entry with the canonical `/kb [text/URL/path]`, matching `command-reference.md` and the dispatcher routing surface.
 - **Lychee local compatibility** — adjusted the dead-link config so local Lychee versions that do not accept `include_fragments = false` can parse it, disabled local cache artifacts, and excluded the generated workspace `index.html` template whose relative links are valid only after setup renders it into an adopter KB.
 


### PR DESCRIPTION
## What changed

- Replaced stale root `/skills/` and `/agents/` CODEOWNERS globs with the current `plugins/kb/skills/` and `plugins/kb/agents/` paths.
- Added explicit `plugins/kb/utils/` and `plugins/kb/commands/` maintainer ownership entries.
- Kept the broad `/plugins/` rule before the more specific KB plugin rules because this CODEOWNERS file uses later-match-wins ordering.
- Recorded the fix under `CHANGELOG.md` `[Unreleased]`.

## Why

The v5.x reorg moved skills and agents under `plugins/kb/`, so the old root paths no longer matched real files. Skill and agent edits therefore fell through to the broad plugin owner rule and missed the intended `@skill-authors` reviewer bucket.

## Impact

No runtime or spec behavior changes. CODEOWNERS now reflects the on-disk layout and will route skill/agent reviews correctly once the decorative teams exist.

## Validation

- `npx markdownlint-cli2 "docs/**/*.md" "*.md"`
- `/tmp/lychee-bin/lychee-x86_64-unknown-linux-gnu/lychee --config .lychee.toml .`
- `python3 scripts/check_consistency.py`

Closes #119.
