### PR TITLE
Clarify /kb sync concurrency contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
-- **CODEOWNERS plugin paths (#119)** — replaced stale root `/skills/` and `/agents/` ownership globs with the current `plugins/kb/skills/` and `plugins/kb/agents/` layout, keeping those specific rules after the broad `/plugins/` rule so skill and agent edits route to `@skill-authors` when those teams exist.
+- **`/kb sync` contract reconciliation (#124)** — `command-reference.md` and `docs/concurrency.md` now cross-link so `/kb sync [layer]` has one discoverable meaning: cross-reference contributor-scoped topics/findings and reconcile promote conflicts, diverged backlinks, and unresolved topic author-sections. `kb-management`, `kb-roadmap`, and `kb-journeys` skill specs now point at the concurrency contract so adopters reading skill specs in isolation can find the shared-layer rules.
 - **README first command (#117)** — replaced the non-canonical `/kb capture [text/URL/path]` shortlist entry with the canonical `/kb [text/URL/path]`, matching `command-reference.md` and the dispatcher routing surface.
 - **Lychee local compatibility** — adjusted the dead-link config so local Lychee versions that do not accept `include_fragments = false` can parse it, disabled local cache artifacts, and excluded the generated workspace `index.html` template whose relative links are valid only after setup renders it into an adopter KB.
 
@@ -81,7 +81,6 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
-- **Day-in-the-life version drift (#122)** — `docs/examples/day-in-the-life.md` now carries the v6.1.0 header after a command-surface verification pass. The walkthrough makes the external-read preflight explicit and uses the canonical `/kb incident [title]` update flow instead of an undocumented incident-resolve shorthand. `scripts/check_consistency.py` now fails when a markdown file's version header is older than the current framework minor version unless the file is narrowly allowlisted as independently versioned or intentionally pinned.
 - **Release-readiness audit closeout** — version surfaces now agree on v6.1.0 across `VERSION`, manifests, README, and the visual landing page; first-run acceptance now covers delivery/operations and retro notes; and the product-management roadmap/journey command surface is documented as stable setup-proposed functionality rather than an unfinished add-on.
 - **Manifest version drift guard** — `scripts/check_consistency.py` now fails when the root marketplace manifest, Claude marketplace manifest, or generated per-plugin manifest drift from `VERSION`, keeping release metadata aligned in CI.
 - **GitHub Pages release build** — the repository now ships `.nojekyll` so the static landing page deploy does not interpret intentional skill/template tokens as Liquid expressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
-- **`/kb sync` contract reconciliation (#124)** — `command-reference.md` and `docs/concurrency.md` now cross-link so `/kb sync [layer]` has one discoverable meaning: cross-reference contributor-scoped topics/findings and reconcile promote conflicts, diverged backlinks, and unresolved topic author-sections. `kb-management`, `kb-roadmap`, and `kb-journeys` skill specs now point at the concurrency contract so adopters reading skill specs in isolation can find the shared-layer rules.
+- **CODEOWNERS plugin paths (#119)** — replaced stale root `/skills/` and `/agents/` ownership globs with the current `plugins/kb/skills/` and `plugins/kb/agents/` layout, keeping those specific rules after the broad `/plugins/` rule so skill and agent edits route to `@skill-authors` when those teams exist.
+- **`/kb sync` contract reconciliation (#124)** — `command-reference.md` and `docs/concurrency.md` now cross-link so `/kb sync [layer]` has one discoverable meaning: cross-reference contributor-scoped topics/findings and reconcile promote conflicts, diverged backlinks, and unresolved topic author-sections. `kb-management`, `kb-roadmap`, and `kb-journeys` skill specs now point at the concurrency contract so adopters reading skill specs in isolation can find the shared-layer rules; the internal link checker recognizes the generated anchor for headings with punctuation.
 - **README first command (#117)** — replaced the non-canonical `/kb capture [text/URL/path]` shortlist entry with the canonical `/kb [text/URL/path]`, matching `command-reference.md` and the dispatcher routing surface.
 - **Lychee local compatibility** — adjusted the dead-link config so local Lychee versions that do not accept `include_fragments = false` can parse it, disabled local cache artifacts, and excluded the generated workspace `index.html` template whose relative links are valid only after setup renders it into an adopter KB.
 
@@ -81,6 +82,7 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 ### Fixed
 
+- **Day-in-the-life version drift (#122)** — `docs/examples/day-in-the-life.md` now carries the v6.1.0 header after a command-surface verification pass. The walkthrough makes the external-read preflight explicit and uses the canonical `/kb incident [title]` update flow instead of an undocumented incident-resolve shorthand. `scripts/check_consistency.py` now fails when a markdown file's version header is older than the current framework minor version unless the file is narrowly allowlisted as independently versioned or intentionally pinned.
 - **Release-readiness audit closeout** — version surfaces now agree on v6.1.0 across `VERSION`, manifests, README, and the visual landing page; first-run acceptance now covers delivery/operations and retro notes; and the product-management roadmap/journey command surface is documented as stable setup-proposed functionality rather than an unfinished add-on.
 - **Manifest version drift guard** — `scripts/check_consistency.py` now fails when the root marketplace manifest, Claude marketplace manifest, or generated per-plugin manifest drift from `VERSION`, keeping release metadata aligned in CI.
 - **GitHub Pages release build** — the repository now ships `.nojekyll` so the static landing page deploy does not interpret intentional skill/template tokens as Liquid expressions.

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -4,7 +4,7 @@
 
 This guide defines what `agentic-kb` does when two contributors mutate shared layer state at the same time. The structural spec ([`docs/REFERENCE.md`](./REFERENCE.md)) defines layout and formats; the collaboration guide ([`docs/collaboration.md`](./collaboration.md)) defines the human contract. This guide names the concrete conflict cases and the rules `/kb promote`, `/kb sync`, and Git itself follow when contributors collide.
 
-The user-facing `/kb sync [layer]` command contract is canonical in [`command-reference.md`](../plugins/kb/skills/kb-management/references/command-reference.md#digests-&-layer-flow): it covers both contributor-scoped cross-reference reconciliation and the concurrency reconciliation cases in this guide.
+The user-facing `/kb sync [layer]` command contract is canonical in [`command-reference.md`](../plugins/kb/skills/kb-management/references/command-reference.md#digests--layer-flow): it covers both contributor-scoped cross-reference reconciliation and the concurrency reconciliation cases in this guide.
 
 ## Why a separate guide
 
@@ -131,7 +131,7 @@ Until those exist, the rules above are the only contract; CI does not currently 
 - [`docs/REFERENCE.md`](./REFERENCE.md) §4 "Backlink (promoted-record stub)" — backlink format consumed by case 2.
 - [`docs/REFERENCE.md`](./REFERENCE.md) §6 "HTML artifact lifecycle" — `merge=ours` for live overviews referenced in case 4.
 - [`docs/collaboration.md`](./collaboration.md) "Failure modes and recovery" — human-facing summary of the same cases.
-- [`plugins/kb/skills/kb-management/references/command-reference.md`](../plugins/kb/skills/kb-management/references/command-reference.md#digests-&-layer-flow) — `/kb sync [layer]` user-facing command contract.
+- [`plugins/kb/skills/kb-management/references/command-reference.md`](../plugins/kb/skills/kb-management/references/command-reference.md#digests--layer-flow) — `/kb sync [layer]` user-facing command contract.
 - [`plugins/kb/skills/kb-management/references/promote-contract.md`](../plugins/kb/skills/kb-management/references/promote-contract.md) — promote semantics consumed by cases 1 and 2.
 - [`plugins/kb/skills/kb-management/references/audit.md`](../plugins/kb/skills/kb-management/references/audit.md) — K11 (broken backlink), K13 (unresolved promote conflict), K14 (diverged backlink), K15 (unconverged author-sectioned topic).
 

--- a/docs/concurrency.md
+++ b/docs/concurrency.md
@@ -1,8 +1,10 @@
 # Concurrency
 
-> **Version:** 6.1.0 | **Last updated:** 2026-05-22
+> **Version:** 6.1.0 | **Last updated:** 2026-05-24
 
 This guide defines what `agentic-kb` does when two contributors mutate shared layer state at the same time. The structural spec ([`docs/REFERENCE.md`](./REFERENCE.md)) defines layout and formats; the collaboration guide ([`docs/collaboration.md`](./collaboration.md)) defines the human contract. This guide names the concrete conflict cases and the rules `/kb promote`, `/kb sync`, and Git itself follow when contributors collide.
+
+The user-facing `/kb sync [layer]` command contract is canonical in [`command-reference.md`](../plugins/kb/skills/kb-management/references/command-reference.md#digests-&-layer-flow): it covers both contributor-scoped cross-reference reconciliation and the concurrency reconciliation cases in this guide.
 
 ## Why a separate guide
 
@@ -129,6 +131,7 @@ Until those exist, the rules above are the only contract; CI does not currently 
 - [`docs/REFERENCE.md`](./REFERENCE.md) §4 "Backlink (promoted-record stub)" — backlink format consumed by case 2.
 - [`docs/REFERENCE.md`](./REFERENCE.md) §6 "HTML artifact lifecycle" — `merge=ours` for live overviews referenced in case 4.
 - [`docs/collaboration.md`](./collaboration.md) "Failure modes and recovery" — human-facing summary of the same cases.
+- [`plugins/kb/skills/kb-management/references/command-reference.md`](../plugins/kb/skills/kb-management/references/command-reference.md#digests-&-layer-flow) — `/kb sync [layer]` user-facing command contract.
 - [`plugins/kb/skills/kb-management/references/promote-contract.md`](../plugins/kb/skills/kb-management/references/promote-contract.md) — promote semantics consumed by cases 1 and 2.
 - [`plugins/kb/skills/kb-management/references/audit.md`](../plugins/kb/skills/kb-management/references/audit.md) — K11 (broken backlink), K13 (unresolved promote conflict), K14 (diverged backlink), K15 (unconverged author-sectioned topic).
 
@@ -136,4 +139,5 @@ Until those exist, the rules above are the only contract; CI does not currently 
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-24 | Added the bidirectional command-reference link so adopters can see that `/kb sync [layer]` covers both contributor-scoped cross-reference reconciliation and the concurrency reconciliation cases in this guide. Closes #124 | `/kb sync` contract reconciliation |
 | 2026-05-22 | Initial concurrency guide closing audit finding #106 — promote collisions resolve via author-id suffix + `_kb-log/promote-conflicts.md` entry; backlink mutation after promote refuses `/kb` writes against `status: promoted` source files and surfaces a diverged-backlink warning at the next `/kb sync` / `/kb audit`; topic merges land as author-sectioned `## Position — @<author> <date>` blocks so concurrent edits coexist; `.kb-log/` and live overviews follow append-only and `merge=ours` rules already declared in REFERENCE.md §6. New `/kb audit` rules K13–K15 surface unresolved conflicts, diverged backlinks, and long-running author disagreement. Closes audit finding #106 | Concept/spec-gap audit closeout |

--- a/plugins/kb/skills/kb-journeys/SKILL.md
+++ b/plugins/kb/skills/kb-journeys/SKILL.md
@@ -148,6 +148,8 @@ Every journey file opens with a metadata block and required sections. See `refer
 
 Full reference: `references/command-reference.md`.
 
+Concurrency contract: [`docs/concurrency.md`](../../../../docs/concurrency.md) governs shared-layer promote collisions, diverged backlinks, topic merges, and append-only logs. Journey flows that read or write shared KB artifacts must honor the same `/kb sync` and `/kb audit` reconciliation rules.
+
 | Command | Purpose |
 |---|---|
 | `/kb journeys` | Scan state; surface next action (unrendered journey, stale mock, missing readiness) |
@@ -229,6 +231,7 @@ The shipped helper scripts cover artifact rendering and standalone-mock extracti
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-24 | Added a concurrency-contract pointer so journey adopters can find the shared-layer `/kb sync` and `/kb audit` reconciliation rules from the skill spec. Closes #124 | `/kb sync` contract reconciliation |
 | 2026-05-15 | Promoted the journeys skill contract to stable `v1.0.0`, removed draft-status frontmatter, and clarified helper coverage without presenting authoring/audit as unfinished | Release-readiness audit |
 | 2026-05-08 | Bumped to v0.2.0, removed the stale `overview.html.hbs` template claim, and clarified current helper-script coverage plus optional dependency fallbacks | Integration pass |
 | 2026-04-30 | Promoted journey work into the product-management surface: setup-derived ownership, broader journey/flow triggers, and value-oriented step-title rules | Product-management surface integration |

--- a/plugins/kb/skills/kb-management/SKILL.md
+++ b/plugins/kb/skills/kb-management/SKILL.md
@@ -136,6 +136,8 @@ There is **one** user-facing command: `/kb`. Infer layer and action from context
 
 Full command reference: `references/command-reference.md`.
 
+Concurrency contract: [`docs/concurrency.md`](../../../../docs/concurrency.md) defines the promote-collision, diverged-backlink, topic-merge, and append-only log cases that `/kb sync` and `/kb audit` reconcile.
+
 ## Core rules
 
 1. **Run the evaluation gate before persistence.** Score material against the five gate questions. The score is the count of yes answers. Q4 + Q2 form the lighter note gate.
@@ -161,7 +163,7 @@ Full command reference: `references/command-reference.md`.
 | Publish | `/kb publish [file] [layer]` | Package reusable knowledge as a skill and publish it to the target layer marketplace |
 | Digest layer | `/kb digest [layer]` | Pull changes from a parent or adjacent layer |
 | Digest connections | `/kb digest connections` | Pull deltas from configured product repos and trackers |
-| Sync | `/kb sync [layer]` | Cross-reference contributor-scoped topics or findings |
+| Sync | `/kb sync [layer]` | Cross-reference contributor-scoped topics or findings; reconcile promote conflicts, diverged backlinks, and unresolved topic author-sections per [`docs/concurrency.md`](../../../../docs/concurrency.md) |
 | Diff | `/kb diff [layer]` | Show new material per contributor or connection |
 | Migrate | `/kb migrate archives` / `/kb migrate layer-model` | Preview or apply legacy archive and layer-model migrations |
 | Task | `/kb task` / `/kb task done [item]` | Manage focus/backlog |
@@ -252,6 +254,7 @@ The templates this skill instantiates live in `templates/`:
 - `references/connections-lifecycle.md` — connection declaration, watermarks, drift checks, and write-back.
 - `references/tracker-backed-primitives.md` — generic tracker-backed decisions, tasks, ideas, feedback, intake, routing, and audit pattern.
 - `references/capture-routing.md` — destination-layer routing modes for `/kb` capture: default / explicit / reflection-driven, the human-confirmation gate, and the `capture-routing:` config schema.
+- [`docs/concurrency.md`](../../../../docs/concurrency.md) — shared-layer concurrency contract for promote collisions, backlink divergence, topic merges, and append-only logs.
 - `references/promote-contract.md` — staged-review semantics for `/kb promote`.
 - `references/publish-contract.md` — marketplace packaging, safety validation, and publish response contract.
 - `references/rituals.md` — the four rituals in detail.
@@ -263,6 +266,7 @@ The templates this skill instantiates live in `templates/`:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-24 | Added a discoverability pointer to `docs/concurrency.md` and expanded the `/kb sync [layer]` flow row so the management skill exposes both responsibilities: contributor-scoped cross-reference reconciliation and concurrency reconciliation. Closes #124 | `/kb sync` contract reconciliation |
 | 2026-05-23 | Added core rule 12 "Capture target is the active layer unless explicit or confirmed" codifying the three capture-routing modes (default / explicit / reflection-driven) and the mandatory human-confirmation gate for agent-inferred non-default targets. Capture flow row in the layer-aware flow table now names the routing modes. Added `references/capture-routing.md` to the load-on-demand references list. Direct cross-layer capture becomes a first-class flow parallel to `/kb promote`, not an implicit consequence of "context selects another contributor-capable layer" | Artifact layer routing |
 | 2026-05-17 | Tightened primitive creation behavior to respect `primitive-storage`: tracker-backed decisions, tasks, ideas, feature intake, and roadmap items use the configured tracker as canonical operational home while KB files keep summaries/backlinks only | Tracker-backed onboarding design |
 | 2026-05-17 | Added a load-on-demand reference for tracker-backed primitives so teams can use issue trackers as the operational backbone for shared decisions, tasks, ideas, feedback, and feature intake without duplicating KB ownership | Cross-repo tracker-backbone review |

--- a/plugins/kb/skills/kb-management/references/command-reference.md
+++ b/plugins/kb/skills/kb-management/references/command-reference.md
@@ -64,7 +64,7 @@ These four verbs require the layer to declare the matching feature in `.kb-confi
 |-----------|--------|
 | `/kb digest [layer]` | Pull changes from a named parent or adjacent layer into the current layer |
 | `/kb digest connections` | Walk the current layer's declared `connections:` and capture deltas since the last watermark |
-| `/kb sync [layer]` | Cross-reference contributor-scoped topics or findings when the layer uses contributor-scoped primitives |
+| `/kb sync [layer]` | Cross-reference contributor-scoped topics or findings when the layer uses contributor-scoped primitives; reconcile promote conflicts, diverged backlinks, and unresolved topic author-sections per [`docs/concurrency.md`](../../../../../docs/concurrency.md) |
 | `/kb diff [layer]` | Show what's new per contributor or per connected source |
 
 If the target layer is `role: consumer`, `promote` and `publish` must refuse and point to the next valid contributor layer.
@@ -218,6 +218,7 @@ See `output-contract.md` for the full wording contract and examples.
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-24 | Expanded the `/kb sync [layer]` row so it carries both parts of the contract: contributor-scoped cross-reference reconciliation and the concurrency reconciliation cases from `docs/concurrency.md` (promote conflicts, diverged backlinks, and unresolved topic author-sections). Closes #124 | `/kb sync` contract reconciliation |
 | 2026-05-23 | Expanded the Capture & Process section: the `/kb [text/URL/path]` row now names the three capture-routing modes and links to the new `capture-routing.md`; added a `/kb <layer> [input]` row for explicit-mode direct routing to a non-default layer | Artifact layer routing |
 | 2026-05-22 | Documented the retro closure lifecycle (`status: open \| tracked \| closed`, `/kb note end` transition to `tracked`, `/kb audit` K12 rule, `/kb start-week` surfacing unfinished commitments) under the Notes section. Expanded the triage scan "Rituals" signal to make the level-1 manual-nudge contract explicit (no scheduler at level 1, so the user is the only thing that triggers rituals; signal turns into an active nudge instead of just an observation). Closes audit findings #108 and #112 | Concept/spec gap audit |
 | 2026-05-17 | Added command behavior for tracker-backed decisions and tasks: commands propose confirmed tracker mutations when `primitive-storage` says the tracker is canonical, and KB files become summaries/backlinks rather than competing records | Tracker-backed onboarding design |

--- a/plugins/kb/skills/kb-roadmap/SKILL.md
+++ b/plugins/kb/skills/kb-roadmap/SKILL.md
@@ -54,6 +54,8 @@ One entry point — `/kb roadmap` — with context-driven subcommands:
 
 Full reference: `references/command-reference.md`.
 
+Concurrency contract: [`docs/concurrency.md`](../../../../docs/concurrency.md) governs shared-layer promote collisions, diverged backlinks, topic merges, and append-only logs. Roadmap flows that read or write shared KB artifacts must honor the same `/kb sync` and `/kb audit` reconciliation rules.
+
 ## Core rules (always apply)
 
 1. **Every run writes three artifacts** — Markdown, HTML, JSON — with the same base name and timestamp. The JSON is authoritative; MD + HTML render from it.
@@ -254,6 +256,7 @@ The shipped helper script covers config-driven generation and dry-run validation
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-05-24 | Added a concurrency-contract pointer so roadmap adopters can find the shared-layer `/kb sync` and `/kb audit` reconciliation rules from the skill spec. Closes #124 | `/kb sync` contract reconciliation |
 | 2026-05-15 | Promoted the roadmap skill contract to stable `v1.0.0`, removed draft-status frontmatter, and clarified that apply-capable flows are stable but gated by explicit commands and confirmations | Release-readiness audit |
 | 2026-05-08 | Bumped to v0.2.0 and clarified the current helper-script adapter/runtime coverage against the broader draft command surface | Integration pass |
 | 2026-04-30 | Promoted roadmap work into the product-management surface: added value-first presentation rules, draft/agreed/shipped commitment visibility, setup-proposed status, and broader natural-language triggers | Product-management surface integration |

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -105,6 +105,13 @@ def normalize_anchor(text: str) -> str:
     return value
 
 
+def github_anchor(text: str) -> str:
+    value = text.strip().lower()
+    value = re.sub(r"\s", "-", value)
+    value = re.sub(r"[`*_~\[\](){}.!?,:;\"'\\&]", "", value)
+    return value.strip("-")
+
+
 def is_external(target: str) -> bool:
     lower = target.lower()
     return any(
@@ -253,7 +260,9 @@ def check_internal_links() -> list[str]:
             else:
                 txt = p.read_text(encoding="utf-8", errors="ignore")
                 heading_cache[p] = {
-                    normalize_anchor(m.group(1)) for m in HEADING_RE.finditer(txt)
+                    anchor
+                    for m in HEADING_RE.finditer(txt)
+                    for anchor in (normalize_anchor(m.group(1)), github_anchor(m.group(1)))
                 }
         return heading_cache[p]
 
@@ -288,7 +297,7 @@ def check_internal_links() -> list[str]:
                 errors.append(f"{rel} -> {raw} (target missing)")
                 continue
             if anchor and target.suffix.lower() == ".md":
-                if normalize_anchor(anchor) not in headings_of(target):
+                if anchor not in headings_of(target) and normalize_anchor(anchor) not in headings_of(target):
                     errors.append(f"{rel} -> {raw} (anchor '{anchor}' missing)")
     return errors
 


### PR DESCRIPTION
## What changed
- Expanded the `/kb sync [layer]` contract to cover both contributor-scoped reconciliation and concurrency reconciliation.
- Added concurrency-contract pointers to the management, roadmap, and journeys skill specs.
- Cross-linked `docs/concurrency.md` back to the command reference.

## Validation
- `python3 scripts/check_consistency.py`
- `npx markdownlint-cli2 "docs/**/*.md" "*.md"`
- `lychee --config .lychee.toml .` could not run locally because `lychee` is not installed in this environment.

Closes #124