### PR TITLE
fix: check plugin spec metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The spec uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html): `MAJOR
 
 - **Default work backend (#145)** — switched the shared process/operational primitive default from file-backed KB records to GitHub Issues. Personal/private layers still default to files, but shared decisions, tasks, feature intake, and roadmap items now use a generated `github-issues` tracker profile unless setup records an explicit file-backed fallback.
 
+### Fixed
+
+- **Plugin spec consistency coverage (#144)** — `scripts/check_consistency.py` now scans `plugins/kb/agents/*.md`, skill `SKILL.md` files, and skill `references/*.md` recursively while skipping scaffold templates. Newly covered plugin references now carry required version/changelog metadata so missing long-lived spec metadata fails CI.
+
 ## [6.2.0] — 2026-05-24
 
 > **Why MINOR:** this release formalizes the v6.1-era audit closeout work that had already landed in the docs. It adds non-breaking contracts for capture routing, concurrency, promoted-record backlinks, retro closure, HTML artifact lifecycle, marketplace conflict handling, setup first-win behavior, and tracker-backed onboarding while keeping the v6 layer graph and existing command surface compatible.

--- a/plugins/kb/skills/kb-journeys/references/artifact-contract.md
+++ b/plugins/kb/skills/kb-journeys/references/artifact-contract.md
@@ -1,5 +1,7 @@
 # Reference: journey artifact contract
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Inputs
 
 - The configured `journeys.source-dir` directory tree (default `_kb-journeys/`).
@@ -106,4 +108,5 @@ Every generated page carries a `<meta name="generator" content="kb-journeys v<ve
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-08 | Aligned the journey artifact contract with the shipped overview/index output, current metadata rendering, and optional dependency fallback behavior | Integration pass |

--- a/plugins/kb/skills/kb-journeys/references/audit.md
+++ b/plugins/kb/skills/kb-journeys/references/audit.md
@@ -1,5 +1,7 @@
 # Reference: `/kb journeys audit`
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Full-sweep consistency audit for the journeys primitive. Runs every structural, traceability, readiness, and mock-integrity rule defined by `kb-journeys` and reports each violation with a proposed correction. Every violation is actionable: the user can accept, reject, or defer the offered correction through the follow-up command or authoring flow.
 
 ## When to run
@@ -127,4 +129,5 @@ Roadmap-specific checks that compare plan items to journey readiness remain owne
 
 | Date | What changed | Source |
 |------|--------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-24 | Added the canonical J1-J19 journeys audit rule set, output contract, resolution actions, and KB-wide delegation contract so `/kb journeys audit` has a version-pinnable reference | Issue #125 |

--- a/plugins/kb/skills/kb-journeys/references/authoring.md
+++ b/plugins/kb/skills/kb-journeys/references/authoring.md
@@ -1,5 +1,7 @@
 # Reference: journey authoring commands
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 `kb-journeys` shares the four-command authoring arc with `kb-roadmap` (`ideate` / `discuss` / `review` / `refine`), with journey-specific deltas. See `kb-roadmap/references/authoring-commands.md` for the shared stance contract.
 
 ## Shared contract
@@ -96,3 +98,9 @@ When invoked this way, the review stance:
 - On `/kb journeys refine` success, the drift finding is marked **resolved** and the journey is re-rendered.
 
 This is the only supported path for journey edits driven by delivery drift. Journeys are **never** silently updated by roadmap runs.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-journeys/references/command-reference.md
+++ b/plugins/kb/skills/kb-journeys/references/command-reference.md
@@ -1,5 +1,7 @@
 # Reference: `/kb journeys` command reference
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Base command
 
 ```
@@ -123,5 +125,6 @@ Command-specific contracts above take precedence when they are narrower, such as
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-25 | Aligned `/kb journeys audit` with the canonical J1-J19 audit reference, including resolution flags, triple artifacts, policy knobs, and exit codes | PR #141 review |
 | 2026-05-08 | Clarified the shipped `render`/`extract-mocks` helper behavior, discovery rules, and optional dependency fallbacks | Integration pass |

--- a/plugins/kb/skills/kb-journeys/references/config-schema.md
+++ b/plugins/kb/skills/kb-journeys/references/config-schema.md
@@ -1,5 +1,7 @@
 # Reference: `.kb-config/layers.yaml` `journeys:` block
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Full schema with defaults.
 
 ```yaml
@@ -73,4 +75,5 @@ journeys:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-04-30 | Added setup-written ownership metadata and clarified that layered journey inheritance remains future work | Product-management surface integration |

--- a/plugins/kb/skills/kb-journeys/references/folder-layout.md
+++ b/plugins/kb/skills/kb-journeys/references/folder-layout.md
@@ -1,5 +1,7 @@
 # Reference: folder layout
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Default layout
 
 ```
@@ -63,3 +65,9 @@ Hyphen, not dot, separates tier.phase from the slug in the filename (dots in fil
 ## Retention
 
 The journey primitive has no retention policy — journey markdown is source and lives indefinitely. Generated HTML is regenerable, so no archive is needed.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-journeys/references/mocks.md
+++ b/plugins/kb/skills/kb-journeys/references/mocks.md
@@ -1,5 +1,7 @@
 # Reference: mock extraction
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Why this exists
 
 A journey markdown file often embeds UI or terminal mocks that illustrate a step. Readers and reviewers need to link to a specific mock in isolation — for a Slack message, a PR review comment, a presentation, or to iterate the mock without scrolling through the whole journey. The extractor turns every inline mock into its own standalone HTML page and back-links both directions.
@@ -87,3 +89,9 @@ Running the extractor twice with no source change produces byte-identical output
 ## Integration with `render`
 
 `kb-journeys render` runs the extractor as its last step. `kb-journeys extract-mocks` is the extractor-only command, useful when only mock content changed.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-journeys/references/structure.md
+++ b/plugins/kb/skills/kb-journeys/references/structure.md
@@ -1,5 +1,7 @@
 # Reference: journey markdown structure
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Every journey markdown file follows this contract. `kb-journeys render` validates it; `kb-journeys audit` reports violations.
 
 ## File-level metadata block
@@ -140,4 +142,5 @@ See `templates/journey-overview.md.hbs` for the scaffold.
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-25 | Replaced the obsolete inline audit checklist with a pointer to the canonical J1-J19 audit reference | PR #141 review |

--- a/plugins/kb/skills/kb-management/references/audit.md
+++ b/plugins/kb/skills/kb-management/references/audit.md
@@ -1,5 +1,7 @@
 # Reference: `/kb audit`
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 KB-wide consistency audit. Runs the foundational checks directly, then delegates scope-specific audits to installed primitive skills (`kb-roadmap`, `kb-journeys`) and consolidates the results into a single report with offered corrections.
 
 ## When to run
@@ -106,6 +108,7 @@ Every resolution respects the existing safety gates (tracker writes need `--appl
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-24 | Linked delegated roadmap and journeys audits to their canonical audit references and replaced the inline journeys checklist with the J1-J19 delegated rule summary from `kb-journeys/references/audit.md` | Issue #125 |
 | 2026-05-23 | Tightened K16 wording so it is mechanically checkable: it now cites the required `routing-mode` / `correlation-id` log keys, the propose → confirm → capture line ordering, and the supported-fallback exemption. Aligned with the "Log format" subsection added to [`capture-routing.md`](./capture-routing.md) | Copilot review #116 |
 | 2026-05-23 | Added K16 (`capture-routing-unconfirmed` — every reflection-driven capture has a paired confirmation entry in `.kb-log/` before the mutation) for the capture-routing contract in [`capture-routing.md`](./capture-routing.md). Updated the output-shape line to reference K1-K16 | Artifact layer routing |

--- a/plugins/kb/skills/kb-management/references/capture-routing.md
+++ b/plugins/kb/skills/kb-management/references/capture-routing.md
@@ -1,5 +1,7 @@
 # Capture Routing — choosing the destination layer for a new artifact
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 This reference defines **which layer a `/kb` capture lands in**, and when the agent may write that artifact directly into a non-default layer without first staging it as a private finding for later promotion.
 
 `/kb promote` moves material that **matured upward**. Capture routing is parallel, not a substitute: it answers the prior question of where a captured task, decision, note, or finding should live **the first time it is written**, when the destination is already clear and a private-first hop would just generate work.
@@ -180,6 +182,7 @@ For mode 3 the response **before** the mutation is the proposed-routing block ab
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-24 | Added the reflection-driven inference heuristics subsection defining strong signals, weak signals, concrete examples, and the deepest-layer tie-breaker so agents have an operational rubric for when to propose a non-default capture target. The routing-mode table now points at this rubric instead of relying on vague "clearly implies" wording | Issue #126 |
 | 2026-05-23 | Review-feedback follow-up on the initial reference: fixed the broken YAML in the `capture-routing:` example (the `source: paste-prefix: "TEAM-PLATFORM:"` line had two `:` tokens at the same indentation, restructured as a single quoted scalar `source: "paste-prefix:TEAM-PLATFORM:"`); rephrased the "Default mode is the floor" sentence to name the modes explicitly instead of referencing an `(b)` label that did not exist; added the "Log format" subsection declaring the three reserved operations (`capture-routing-propose`, `capture-routing-confirm`/`capture-routing-reject`, `capture`), their required `details` keys, the `correlation-id` rules, and a worked example so audit rule K16 is mechanically checkable. Audit K16 wording tightened accordingly | Copilot review #116 |
 | 2026-05-23 | Initial reference. Codifies the three capture-routing modes (default / explicit / reflection-driven), the `capture-routing:` config schema, the mandatory confirmation gate for agent-inferred non-default targets, the "do not write while waiting for confirmation" rule, the audit rule K16, and the relationship to `/kb promote` and `auto-promote`. Closes the spec gap where direct cross-layer capture was implicitly possible (via "context selects another contributor-capable layer") but never named as a deliberate alternative to the private→shared promote chain | Artifact layer routing |

--- a/plugins/kb/skills/kb-management/references/command-reference.md
+++ b/plugins/kb/skills/kb-management/references/command-reference.md
@@ -1,5 +1,7 @@
 # Command Reference — kb-management
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Capture & Process
 
 | Subcommand | Action |
@@ -218,6 +220,7 @@ See `output-contract.md` for the full wording contract and examples.
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-24 | Expanded the `/kb sync [layer]` row so it carries both parts of the contract: contributor-scoped cross-reference reconciliation and the concurrency reconciliation cases from `docs/concurrency.md` (promote conflicts, diverged backlinks, and unresolved topic author-sections). Closes #124 | `/kb sync` contract reconciliation |
 | 2026-05-23 | Expanded the Capture & Process section: the `/kb [text/URL/path]` row now names the three capture-routing modes and links to the new `capture-routing.md`; added a `/kb <layer> [input]` row for explicit-mode direct routing to a non-default layer | Artifact layer routing |
 | 2026-05-22 | Documented the retro closure lifecycle (`status: open \| tracked \| closed`, `/kb note end` transition to `tracked`, `/kb audit` K12 rule, `/kb start-week` surfacing unfinished commitments) under the Notes section. Expanded the triage scan "Rituals" signal to make the level-1 manual-nudge contract explicit (no scheduler at level 1, so the user is the only thing that triggers rituals; signal turns into an active nudge instead of just an observation). Closes audit findings #108 and #112 | Concept/spec gap audit |

--- a/plugins/kb/skills/kb-management/references/connections-lifecycle.md
+++ b/plugins/kb/skills/kb-management/references/connections-lifecycle.md
@@ -1,5 +1,7 @@
 # Connections — setup and lifecycle
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 This reference covers how to declare, configure, and maintain external connections for a layer. Connections give `/kb digest connections` its source list, and they appear in triage drift checks and `start-day` briefings.
 
 ## What a connection is
@@ -191,6 +193,7 @@ To stop tracking a connection:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-18 | Relabeled the Write-back section as RESERVED (not implemented in v6.1.0): `writeback.enabled: true` is a no-op today; the planned contract is preserved as the future spec; open questions (which trackers, auth model, source-of-truth rule, concurrent-write semantics) are now explicit. `kb-setup` must not propose `writeback.enabled: true` in v6.1.0. Closes audit finding #102 | Concept/onboarding/process audit |
 | 2026-05-17 | Clarified that tracker connections and tracker-backed primitive ownership are separate config concerns: `connections.trackers[]` describes access, while `primitive-storage` declares canonical ownership | Tracker-backed onboarding design |
 | 2026-04-27 | Added a dedicated reference for connection kinds, config shape, setup flow, digest lifecycle, watermark format, triage drift checks, write-back, and disconnect behavior; aligned repo-as-OS bridge wording to the current `connections.product-repos[]` schema | Documentation gap follow-up |

--- a/plugins/kb/skills/kb-management/references/evaluation-gate.md
+++ b/plugins/kb/skills/kb-management/references/evaluation-gate.md
@@ -1,5 +1,7 @@
 # The Evaluation Gate — kb-management
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Applied at **every persistence boundary**. The gate is the system's immune system.
 
 ## The five questions
@@ -86,4 +88,5 @@ The gate is **not a hard blocker**. If the user insists after being told the rat
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-04-22 | Reframed Q5 as positive novelty, clarified that the gate score is the count of ✅ yes answers, and fixed the worked examples/log wording to match the rubric | Fixes #30 |

--- a/plugins/kb/skills/kb-management/references/html-artifacts.md
+++ b/plugins/kb/skills/kb-management/references/html-artifacts.md
@@ -1,5 +1,7 @@
 # HTML Artifact Generation — kb-management
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Two families of artifacts:
 
 1. **Always-current overviews** — regenerated after any state-mutating operation. Overwritten in place. No version number; timestamp watermark.
@@ -294,6 +296,7 @@ Every `/kb present` MUST use this file (as customized by the phase-3 HTML-stylin
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-22 | Added "Commit policy, hosting, and merge strategy" subsection pointing at the new `docs/REFERENCE.md` §6 lifecycle contract: anchor-layer live overviews are tracked (+ `merge=ours` via `.gitattributes`); non-anchor live overviews are ignored by default; historical artifacts are always tracked; `/kb status --refresh-overviews` is the repair path. Generators must keep live overview output deterministic so `merge=ours` converges cleanly on the next regen. Closes audit finding #107 | Concept/spec gap audit |
 | 2026-05-15 | Reframed external-read examples to refer to stable roadmap/journey skills instead of optional draft skills | Release-readiness audit |
 | 2026-05-10 | Corrected the daily-summary and weekly-summary finding paths in the historical-artifacts table from `findings/YYYY-MM-DD-*.md` to the year-nested `findings/YYYY/YYYY-MM-DD-*.md` shape used everywhere else in the spec | v6.0.0 adoption + daily-usage gap audit |

--- a/plugins/kb/skills/kb-management/references/output-contract.md
+++ b/plugins/kb/skills/kb-management/references/output-contract.md
@@ -1,5 +1,7 @@
 # Output Contract — collaboration-safe review
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 This document defines the response contract for `agentic-kb` operations where humans need to review or trust what an agent did.
 
 The top-level rule stays the same: keep output terse. But terse does not mean ambiguous.
@@ -220,4 +222,5 @@ Suggested next steps:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-10 | Added the missing `## Changelog` section so this reference satisfies AGENTS rule 3. No semantic changes to the action-mode rules, the four required sections, or the example outputs | v6.0.0 adoption + daily-usage gap audit |

--- a/plugins/kb/skills/kb-management/references/promote-contract.md
+++ b/plugins/kb/skills/kb-management/references/promote-contract.md
@@ -1,5 +1,7 @@
 # Promote Contract — staged review semantics
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 This reference defines what `/kb promote` means once a source artifact is judged mature enough to move upward.
 
 `/kb promote` is the **upward-after-maturation** path. It is parallel to (not a substitute for) [`capture-routing.md`](./capture-routing.md), which covers the **first-write destination** for new artifacts. If a capture's correct destination was clear from the start — pre-instructed by the user, matched by a configured rule, or confirmed when the agent reflected on the input — direct routing writes the artifact in the target layer without ever needing this promote flow.
@@ -94,6 +96,7 @@ Concurrent promotes (two contributors promoting the same artifact, or revising a
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-23 | Added the preamble that names this as the upward-after-maturation flow and points at [`capture-routing.md`](./capture-routing.md) as the parallel first-write-destination flow. Stops adopters from reading promote as the *only* way artifacts cross layers | Artifact layer routing |
 | 2026-05-22 | Added "Concurrency" subsection pointing at [`docs/concurrency.md`](../../../../../docs/concurrency.md): promote collisions resolve via author-id suffix + `_kb-log/promote-conflicts.md` entry; backlink mutation after promote refuses `/kb` writes and surfaces a diverged-backlink warning. Closes audit finding #106 | Audit-tracker closeout |
 | 2026-05-22 | Added "Backlink stub format" subsection codifying the `status: promoted` + `canonical:` + `promoted-at` frontmatter and the standardized banner body that replaces a source-layer record when canonical ownership shifts upward, with rules for path resolution, evidence migration, audit detection (K11), and migration-helper rewrites. Closes audit finding #111 | Concept/spec gap audit |

--- a/plugins/kb/skills/kb-management/references/publish-contract.md
+++ b/plugins/kb/skills/kb-management/references/publish-contract.md
@@ -1,5 +1,7 @@
 # Publish Contract — skill packaging and marketplace submission
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 This reference defines what `/kb publish` means once a source artifact contains a generalizable pattern worth sharing through a layer's marketplace.
 
 ## What publish is not
@@ -152,5 +154,6 @@ Suggested next steps:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-22 | Added "Versioning, dependencies, install-mode, priority" subsection: skills MUST declare SemVer `version:`; `dependencies:` is resolved before install; marketplace repos declare `install-mode: open \| review-required` (public marketplaces MUST be `review-required`); cross-marketplace conflicts resolve via `priority:` with shadow warnings. PR body must list the proposed version bump, resolved dependencies, marketplace install-mode, and any shadowed skills. Full normative contract lives in `docs/REFERENCE.md` §11. Closes audit finding #113 | Concept/spec gap audit |
 | 2026-04-27 | Added a dedicated publish reference covering the transformation boundary of `/kb publish`, the generalizability gate, safety validation, package layout, and response contract; aligned package paths to the current marketplace layout in `docs/REFERENCE.md` §11 | Documentation gap follow-up |

--- a/plugins/kb/skills/kb-management/references/rituals.md
+++ b/plugins/kb/skills/kb-management/references/rituals.md
@@ -1,5 +1,7 @@
 # Rituals — kb-management
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Invariants for every ritual
 
 1. Start with `/kb status` mental check.
@@ -65,4 +67,5 @@ Rituals are idempotent within a day / week — running twice doesn't duplicate l
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-10 | First changelog row in this file (closes the AGENTS rule 3 gap), plus three drift fixes the v6 audit surfaced: replaced the retired `SKILL.md rule #11c` cross-references with pointers to the current rule 8 (Task creation and closure are explicit); corrected the task-archive path from `_kb-tasks/archive/YYYY-MM.md` to the canonical `_kb-tasks/archive/YYYY/MM.md` declared in `docs/REFERENCE.md` §3 so end-of-day archival writes to the right place; corrected the weekly-summary finding path to the year-nested `_kb-references/findings/YYYY/YYYY-MM-DD-weekly-summary.md` shape used everywhere else in the spec | v6.0.0 adoption + daily-usage gap audit |

--- a/plugins/kb/skills/kb-management/references/spec-summary.md
+++ b/plugins/kb/skills/kb-management/references/spec-summary.md
@@ -1,5 +1,7 @@
 # Spec Summary — for the kb-management skill
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Condensed runtime reference for the skill. For the full spec, see `docs/REFERENCE.md`.
 
 ## Layer graph
@@ -100,4 +102,5 @@ Scopes are descriptive, not numbered: `personal`, `team`, `org-unit`, `company`,
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-10 | Added the missing `## Changelog` section so this reference satisfies AGENTS rule 3. No semantic changes to the layer-graph summary, the layout examples, the config shape, the log-line format, or the descriptive scope list | v6.0.0 adoption + daily-usage gap audit |

--- a/plugins/kb/skills/kb-management/references/tracker-backed-primitives.md
+++ b/plugins/kb/skills/kb-management/references/tracker-backed-primitives.md
@@ -1,5 +1,7 @@
 # Tracker-Backed Primitives
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Some teams already run their day-to-day product and delivery work through an issue tracker. `agentic-kb` should support that pattern without turning the KB into a duplicate tracker.
 
 This reference defines the generic pattern for using tracker items as the operational backbone for decisions, ideas, tasks, feedback, and feature intake while keeping KB files as synthesis, evidence, and artifact memory.
@@ -232,6 +234,7 @@ Watch for these problems:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-06-02 | Changed the tracker-backed primitive default so shared process/operational primitives default to GitHub Issues-backed ownership, while personal/private layers stay file-backed and shared file-backed mode must be explicit | Issue #145 |
 | 2026-05-17 | Expanded the proposal into an onboarding contract: setup now asks which primitives are file-backed, tracker-backed, or hybrid; records `primitive-storage` beside tracker connections; and treats generic GitHub/Jira setup packages, governance CI, labeler/PR templates, manual setup checklists, and tracker workflow skills as expected onboarding outcomes | Tracker-backed onboarding design |
 | 2026-05-17 | Added the generic tracker-backed primitive pattern for teams that use issue trackers as the operational backbone for feedback, ideas, decisions, tasks, and feature intake | Cross-repo tracker-backbone review |

--- a/plugins/kb/skills/kb-roadmap/references/adapters.md
+++ b/plugins/kb/skills/kb-roadmap/references/adapters.md
@@ -1,5 +1,7 @@
 # Reference: source adapters
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Adapters normalize heterogeneous plan and delivery sources into a common item shape. The draft behavioral spec covers the full set below. The shipped helper script in this repo currently implements `ticket-export-markdown` and `github-issues`; the remaining adapters stay documented as the next extension points so the published surface remains explicit.
 
 ## Common item shape
@@ -178,5 +180,6 @@ Collisions raise an explicit error — no silent override.
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-08 | Clarified which roadmap adapters are implemented by the shipped helper script versus still spec-only in the draft contract | Integration pass |
 | 2026-04-22 | Replaced an internal example label with a generic one to keep the roadmap adapter reference vendor-neutral | Vendor-neutrality rescreen |

--- a/plugins/kb/skills/kb-roadmap/references/artifact-contract.md
+++ b/plugins/kb/skills/kb-roadmap/references/artifact-contract.md
@@ -1,5 +1,7 @@
 # Reference: artifact output contract
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Every `/kb roadmap` run emits three files with the same base name under the scope-specific directory:
 
 ```
@@ -133,5 +135,6 @@ The helper's JSON payload does not currently carry the SKILL version field. Comp
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-08 | Aligned the artifact contract with the shipped helper output shape, roll-up filename rule, and root index refresh behavior | Integration pass |
 | 2026-04-30 | Updated the JSON sidecar version example to match kb-roadmap v0.2.0 | Product-management surface integration |

--- a/plugins/kb/skills/kb-roadmap/references/audit.md
+++ b/plugins/kb/skills/kb-roadmap/references/audit.md
@@ -1,5 +1,7 @@
 # Reference: `/kb roadmap audit`
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Full-sweep consistency audit for the roadmap scope. Runs every rule defined across the skill and reports each violation with a proposed correction. Every violation is actionable — the user can accept, reject, or defer.
 
 ## When to run
@@ -112,3 +114,9 @@ When `/kb roadmap` runs the state machine and finds a recent audit artifact with
 | 1 | Config error (skill cannot run) |
 | 2 | Violations exceed severity-gate |
 | 3 | User deferred one or more resolutions without completing |
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-roadmap/references/authoring-commands.md
+++ b/plugins/kb/skills/kb-roadmap/references/authoring-commands.md
@@ -1,5 +1,7 @@
 # Reference: item authoring commands
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Roadmap items move through a creative and critical authoring arc before they enter the delivery pipeline. The skill ships four dedicated authoring commands, each with a distinct stance:
 
 | Command | Stance | Produces |
@@ -231,3 +233,9 @@ When the scope has a tracker with `write-*` capabilities declared, each authorin
 | `refine` | Attach the implementation plan as a comment and propose a status transition to `defined` (if `write-comments` + `write-status`) |
 
 All tracker writes are gated by `--apply` + interactive confirmation, matching the safety rules in `issue-trackers.md`.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-roadmap/references/command-reference.md
+++ b/plugins/kb/skills/kb-roadmap/references/command-reference.md
@@ -1,5 +1,7 @@
 # Reference: `/kb roadmap` command reference
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Base command
 
 The behavioral spec below describes the intended `/kb roadmap` surface. The shipped helper script in this repo currently implements config-driven generation for detail/roll-up scopes plus `--dry-run`; interactive mutation flows remain draft-spec behavior.
@@ -143,4 +145,5 @@ Exit code 3 is a hook for CI / scheduled runs: fail the job when new unplanned-d
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-08 | Clarified which `/kb roadmap` behaviors are covered by the shipped helper script versus the broader draft command spec | Integration pass |

--- a/plugins/kb/skills/kb-roadmap/references/config-schema.md
+++ b/plugins/kb/skills/kb-roadmap/references/config-schema.md
@@ -1,5 +1,7 @@
 # Reference: active-layer `roadmap:` block in `.kb-config/layers.yaml`
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Full schema with defaults.
 
 The active layer may also declare trackers under `connections.trackers[]`. At 5.1, the roadmap pilot normalizes those connection-backed trackers into read-only `issue-trackers[]` entries when the legacy per-skill block is absent.
@@ -169,5 +171,6 @@ roadmap:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-04-30 | Added the presentation-view config surface for phase/lane roadmap boards, customer-value headlines, draft callouts, and implemented markers | Product-management surface integration |
 | 2026-04-25 | Clarified the 5.1 config contract: the active layer owns the roadmap block, `connections.trackers[]` can seed read-only tracker inputs, and `issue-trackers[]` is now documented as a legacy or override surface | v5.1.0 closeout release |

--- a/plugins/kb/skills/kb-roadmap/references/correlation-ladder.md
+++ b/plugins/kb/skills/kb-roadmap/references/correlation-ladder.md
@@ -1,5 +1,7 @@
 # Reference: the five-tier correlation ladder
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 The correlation engine matches plan items (tickets, milestones) to delivery signals (commits, PRs, tags, ADRs). It applies tiers in order and stops at the first match. Every matched pair records its tier for later auditing; every unmatched item flows to tier 5 (mismatch finding).
 
 ## Tier 1 — Direct key match
@@ -88,3 +90,9 @@ Each match records:
 ```
 
 The JSON sidecar preserves the full ladder output so future runs can diff correlation quality over time.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-roadmap/references/discuss-mode.md
+++ b/plugins/kb/skills/kb-roadmap/references/discuss-mode.md
@@ -1,5 +1,7 @@
 # Reference: `/discuss` mode
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Intent
 
 By default the skill **proposes changes and writes them** (artifact regeneration, tuning application, sync application). `/discuss` flips the contract: the skill must not write anything. It explains, answers, and asks — the user drives edits.
@@ -29,3 +31,9 @@ Any `/kb roadmap` invocation where the user message contains `/discuss` (as a to
 ## Why
 
 The user keeps autonomy. `/discuss` is the on-ramp for a human to understand what the skill *would* do before authorizing it. It is a deliberate low-energy mode — useful for reviewing a new scope, validating a tuning proposal, or sanity-checking correlation results without letting the skill mutate state.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-roadmap/references/folder-layout.md
+++ b/plugins/kb/skills/kb-roadmap/references/folder-layout.md
@@ -1,5 +1,7 @@
 # Reference: folder layout and views
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 The skill emits into a dedicated `_kb-roadmaps/` folder at the adopter's KB root. This folder is a peer of `_kb-references/`, `_kb-decisions/`, `_kb-ideas/`, `_kb-tasks/` — not a subdirectory of reports — because roadmaps are a distinct primitive from strategic reports.
 
 ## Layout
@@ -76,4 +78,5 @@ The `archive/` directory is reserved for future retention handling. The shipped 
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-08 | Removed unimplemented `status-*` outputs and clarified the current helper-script behavior for roll-up scopes and root index generation | Integration pass |

--- a/plugins/kb/skills/kb-roadmap/references/html-template.md
+++ b/plugins/kb/skills/kb-roadmap/references/html-template.md
@@ -1,5 +1,7 @@
 # Reference: Generated HTML roadmap — template contract
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Every `/kb roadmap` run emits a **triple artifact** (`.md` + `.html` + `.json`) into `<output-dir>/<scope>/roadmap-<YYYY-MM-DD>.*`. This file documents the **HTML contract** — what sections must appear, how they are derived, and how adopters customize them without forking the renderer.
 
 ## Sections (required, in this order)
@@ -106,4 +108,5 @@ If a customization would require changing any of the above, open an agentic-kb i
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-04-30 | Added the optional phase/lane presentation board contract with value headlines, detail lines, draft/agreed/shipped visibility, and no-loss overflow behavior | Product-management surface integration |

--- a/plugins/kb/skills/kb-roadmap/references/issue-trackers.md
+++ b/plugins/kb/skills/kb-roadmap/references/issue-trackers.md
@@ -1,5 +1,7 @@
 # Reference: issue trackers as first-class sources
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Why this exists
 
 Organizations track plans across heterogeneous systems — GitHub issues, Jira, Linear, a Notion board, a spreadsheet — and correlate delivery in a separate system. The skill treats *every* such system as an **issue tracker** with a common capability surface, not as a one-off "plan source".
@@ -99,6 +101,7 @@ Earlier schema used `plan-sources:` generically. Trackers are a specialized plan
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-04-25 | Updated the tracker reference to prefer active-layer `connections.trackers[]` and recast `issue-trackers[]` as the legacy/override surface for the 5.1 closeout | v5.1.0 closeout release |
 
 Adopters can mix both in the same scope.

--- a/plugins/kb/skills/kb-roadmap/references/journey-grounding.md
+++ b/plugins/kb/skills/kb-roadmap/references/journey-grounding.md
@@ -1,5 +1,7 @@
 # Reference: journey grounding
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Journeys are the **ground truth** for what should become reality. Tracker items describe *intent to build something*; journeys describe *what the product must actually do*. When the two diverge, the journey wins — the roadmap is there to close the gap, not the other way round.
 
 This reference defines how `kb-roadmap` uses `kb-journeys` artifacts as a reference, a review lens, and a consistency check for every roadmap run.
@@ -127,3 +129,9 @@ roadmap:
       route-classes: [journey-uncovered, journey-citation-broken, journey-reality-mismatch]
       min-uncovered-to-find: 1              # suppress spam when entire journey is future work
 ```
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-roadmap/references/mismatch-findings.md
+++ b/plugins/kb/skills/kb-roadmap/references/mismatch-findings.md
@@ -1,5 +1,7 @@
 # Reference: mismatch findings
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Mismatch findings are the primary value of the skill on imperfect datasets. Where correlation fails, the artifact surfaces *why* — not silently discard.
 
 ## Classes
@@ -75,3 +77,9 @@ The skill exposes two review commands:
 - `/kb roadmap --review-mismatches` — walks section-E entries; user can suppress a class per-source, or add a cross-reference to upgrade it to tier 2 on the next run
 
 Confirmed matches and suppressions persist in `.kb-scripts/roadmap-state.json` so future runs stay stable.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-roadmap/references/phase-gates.md
+++ b/plugins/kb/skills/kb-roadmap/references/phase-gates.md
@@ -1,5 +1,7 @@
 # Reference: phase gates for plan items
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Plan items move through a generic pipeline. Phase markers are declared **inline in each plan item's markdown** (when the tracker exports to markdown) or computed from tracker status mapping (when the tracker is live).
 
 ## Generic phase pipeline
@@ -69,3 +71,9 @@ The forward-plan section (F) groups plan items by phase column instead of by pri
 ## Why this is not VI-specific
 
 The phase names are generic (`idea`, `defined`, `committed`, `in-delivery`, `shipped`, `archived`) and map onto any delivery pipeline — product increments, infrastructure changes, policy decisions, research items. Adopters with their own vocabulary rename phases in config without touching the skill.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-roadmap/references/state-machine.md
+++ b/plugins/kb/skills/kb-roadmap/references/state-machine.md
@@ -1,5 +1,7 @@
 # Reference: state machine and resume routing
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## Motivation
 
 The skill runs on partial data, mid-workflow, with humans in the loop. It must be able to:
@@ -68,3 +70,9 @@ The rules are deterministic, documented, and testable. LLM judgment is not used 
 ## Why this is not VI-specific
 
 The markers are generic status words (`draft`, `reviewed`, `published`, `archived`) and the rules refer only to artifact freshness, review backlog, and unresolved findings. No domain vocabulary.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/plugins/kb/skills/kb-setup/references/automation-levels.md
+++ b/plugins/kb/skills/kb-setup/references/automation-levels.md
@@ -1,5 +1,7 @@
 # Automation Levels — setup contract
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 This reference defines what the setup interview means when it asks for automation level `1`, `2`, or `3`.
 
 ## Canonical levels
@@ -54,5 +56,6 @@ When `/kb setup` writes `.kb-config/automation.yaml`:
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-18 | Added explicit "Scheduler ownership" section (agentic-kb does not ship a scheduler; the adopter wires OS cron / CI / harness-native automation) and a "Confidence threshold (level 3)" section that requires the wizard to confirm threshold + excluded workstreams + a worked example before writing `auto-promote.enabled: true`. Closes audit findings #94 and #105 | Concept/onboarding/process audit |
 | 2026-04-25 | Initial reference defining the setup interview contract for automation levels 1/2/3 and how they map into `.kb-config/automation.yaml` | Deep spec-audit follow-up |

--- a/plugins/kb/skills/kb-setup/references/migration-guide.md
+++ b/plugins/kb/skills/kb-setup/references/migration-guide.md
@@ -1,5 +1,7 @@
 # Migration Guide — kb-setup
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 For users who already have a knowledge base in another layout.
 
 ## Detection
@@ -84,5 +86,6 @@ Create `me.md`, `context.md`, `stakeholders.md`, `sources.md` from templates and
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-05-10 | Corrected the task-archive migration target from the flat `_kb-tasks/archive/YYYY-MM.md` to the canonical `_kb-tasks/archive/YYYY/MM.md` shape defined in `docs/REFERENCE.md` §3, so the migration helper produces a layout that matches the rest of the spec | v6.0.0 adoption + daily-usage gap audit |
 | 2026-04-25 | Added the explicit `/kb migrate layer-model` and `/kb migrate archives` helper guidance for the 5.1 closeout so legacy adopters have a deterministic migration path | v5.1.0 closeout release |

--- a/plugins/kb/skills/kb-setup/references/setup-flow.md
+++ b/plugins/kb/skills/kb-setup/references/setup-flow.md
@@ -1,5 +1,7 @@
 # Setup Flow — step by step
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 Full walkthrough the skill follows on `/kb setup`.
 
 For the deterministic acceptance baseline used to verify real onboarding and team rollout quality, see [`docs/first-run-acceptance.md`](../../../../../docs/first-run-acceptance.md).
@@ -300,6 +302,7 @@ After the quickstart, validate the deterministic rollout baseline against [`docs
 
 | Date | What changed | Source |
 |------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |
 | 2026-06-02 | Changed the setup-flow default so shared process/operational primitives render GitHub Issues-backed `primitive-storage` by default, with explicit file-backed fallback only when GitHub Issues is unavailable or rejected | Issue #145 |
 | 2026-05-18 | VS Code IDE-configuration note rewritten: the `chat.plugins.marketplaces` setting belongs to user-level `settings.json` (workspace settings not honored per the official docs), the surrounding feature is Microsoft Preview, and `scripts/install --target vscode` is recommended as the stable path. Closes audit finding #97 | Concept/onboarding/process audit |
 | 2026-05-18 | Phase order flipped to match `kb-setup` SKILL: phase 1 is now "Workspace and harness facts" (frontloaded), phase 2 is the open-ended "Context and goals" block. Expert-mode skip path made explicit — phase 1 is never skipped because the wizard needs workspace root + IDE targets before it writes anything. Closes audit finding #98 | Concept/onboarding/process audit |

--- a/plugins/kb/skills/kb-setup/references/troubleshooting.md
+++ b/plugins/kb/skills/kb-setup/references/troubleshooting.md
@@ -1,5 +1,7 @@
 # Troubleshooting — kb-setup
 
+> **Version:** 6.3.0 | **Last updated:** 2026-06-02
+
 ## No tools enabled in the VS Code chat session
 
 Symptom: `/kb` or `/kb setup` launches a chat session where the agent reports it has no tools available, or file operations (read / create / edit) fail.
@@ -57,3 +59,9 @@ Every topic and foundation file must end with a `## Changelog` section. The skil
 - Check that the marketplace repo is reachable (VPN / SSO if internal).
 - Re-run with `--force` to overwrite a partial install.
 - Check `scripts/install --help` for harness-specific options.
+
+## Changelog
+
+| Date | What changed | Source |
+|------|-------------|--------|
+| 2026-06-02 | Added required version/changelog metadata so plugin specs and references are covered by the consistency check | Issue #144 |

--- a/scripts/check_consistency.py
+++ b/scripts/check_consistency.py
@@ -20,7 +20,10 @@ from pathlib import Path
 REPO = Path(__file__).resolve().parent.parent
 IGNORED_PATH_PARTS = {".git", "node_modules", ".venv", "venv", "__pycache__"}
 
-LONG_LIVED_DIRS: list[Path] = []
+LONG_LIVED_DIRS: list[Path] = [
+    REPO / "plugins" / "kb" / "agents",
+    REPO / "plugins" / "kb" / "skills",
+]
 OPTIONAL_LONG_LIVED = [REPO / "docs" / "REFERENCE.md", REPO / "docs" / "glossary.md"]
 
 # Files that are allowed to not have a version header.
@@ -67,6 +70,7 @@ def _load_external_blocklist() -> list[str]:
     return terms
 
 VERSION_RE = re.compile(r"\*\*Version:\*\*\s*(\d+)\.(\d+)(?:\.(\d+))?")
+FRONTMATTER_VERSION_RE = re.compile(r"^version:\s*(\d+)\.(\d+)(?:\.(\d+))?\s*$", re.MULTILINE)
 CHANGELOG_RE = re.compile(r"^##\s+Changelog\s*$", re.MULTILINE)
 HEADING_RE = re.compile(r"^#{1,6}\s+(.+?)\s*$", re.MULTILINE)
 INLINE_LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
@@ -82,8 +86,18 @@ def iter_long_lived_docs():
     for d in LONG_LIVED_DIRS:
         if not d.is_dir():
             continue
-        for p in sorted(d.glob("*.md")):
-            yield p
+        for p in sorted(d.rglob("*.md")):
+            rel = p.relative_to(REPO)
+            parts = rel.parts
+            if "templates" in parts:
+                continue
+            if d.name == "agents":
+                if p.parent == d:
+                    yield p
+                continue
+            if d.name == "skills":
+                if p.name == "SKILL.md" or "references" in parts:
+                    yield p
     for p in OPTIONAL_LONG_LIVED:
         if p.is_file():
             yield p
@@ -101,6 +115,10 @@ def parse_version(value: str) -> tuple[int, int, int] | None:
     if not match:
         return None
     return tuple(int(part) for part in match.groups())
+
+
+def has_version_field(text: str) -> bool:
+    return bool(VERSION_RE.search(text) or FRONTMATTER_VERSION_RE.search(text))
 
 
 def normalize_anchor(text: str) -> str:
@@ -131,7 +149,7 @@ def check_versions_and_changelogs() -> list[str]:
     for doc in iter_long_lived_docs():
         text = doc.read_text(encoding="utf-8")
         rel = doc.relative_to(REPO)
-        if doc not in EXEMPT_FROM_VERSION and not VERSION_RE.search(text):
+        if doc not in EXEMPT_FROM_VERSION and not has_version_field(text):
             errors.append(f"MISSING **Version:** field: {rel}")
         if not CHANGELOG_RE.search(text):
             errors.append(f"MISSING '## Changelog' section: {rel}")
@@ -497,4 +515,3 @@ def main() -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-


### PR DESCRIPTION
## Summary
- expand consistency scanning to plugin agents, skill specs, and skill reference docs while skipping scaffold templates
- accept skill frontmatter `version:` as valid metadata for long-lived spec files
- add missing version/changelog metadata to newly covered plugin reference docs

## Validation
- python3 scripts/check_consistency.py
- npx markdownlint-cli2 "docs/**/*.md" "*.md"
- docker run --rm -v "$PWD:/input:ro" -w /input lycheeverse/lychee:latest --config .lychee.toml .
- python3 scripts/check_plugin_structure.py
- python3 scripts/check_html_artifacts.py && python3 scripts/check_report_artifacts.py && python3 scripts/test_html_templates.py && python3 scripts/test_generate_index.py && python3 scripts/test_generate_dashboard.py
- python3 scripts/test_acceptance_fixture.py && python3 scripts/test_kb_roadmap.py && python3 scripts/test_kb_journeys.py && python3 scripts/test_kb_migrations.py && python3 scripts/test_capture_routing.py

Closes #144